### PR TITLE
Add django "south" to installed apps and config.

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,3 +1,4 @@
 # requirements/common.txt: Used on *all* environments.
 
 django==1.6.1
+South==0.8.4

--- a/stagecraft/settings/common.py
+++ b/stagecraft/settings/common.py
@@ -54,6 +54,7 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'south',
 
     'stagecraft.apps.datasets',
 )


### PR DESCRIPTION
South unfortunately didn't make it into Django 1.6.1, and we need it for
database migrations.
