### PR TITLE
Don't exclude test files from PEP8

### DIFF
--- a/pep-it.sh
+++ b/pep-it.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
 
 basedir=$(dirname $0)
-pep8 --exclude=migrations,tests,build,venv "$basedir"
+pep8 --exclude=migrations,build,venv "$basedir"
 pep8 "$basedir/stagecraft/apps/datasets/tests"


### PR DESCRIPTION
We're hand-writing them so I don't see a reason to exclude these.
