### PR TITLE
Factor out create/tear down of data[group|type]

### DIFF
--- a/stagecraft/apps/datasets/tests/models/test_data_set.py
+++ b/stagecraft/apps/datasets/tests/models/test_data_set.py
@@ -3,39 +3,56 @@
 
 from __future__ import unicode_literals
 
-from django.test import TestCase
-
-from django.core.exceptions import ValidationError
+from contextlib import contextmanager
 
 from nose.tools import assert_raises
+
+from django.test import TestCase
+from django.core.exceptions import ValidationError
 
 from stagecraft.apps.datasets.models import DataGroup, DataSet, DataType
 
 
 class DataSetTestCase(TestCase):
-    def test_data_set_name_must_be_unique(self):
-        datagroup1 = DataGroup.objects.create(name='datagroup1')
-        datatype1 = DataType.objects.create(name='datatype1')
-        datatype2 = DataType.objects.create(name='datatype2')
+    @classmethod
+    def setUpClass(cls):
+        cls.data_group1 = DataGroup.objects.create(name='data_group1')
+        cls.data_type1 = DataType.objects.create(name='data_type1')
+        cls.data_type2 = DataType.objects.create(name='data_type2')
 
-        a = DataSet.objects.create(name='foo', data_group=datagroup1,
-                                   data_type=datatype1)
+    @classmethod
+    def tearDownClass(cls):
+        cls.data_group1.delete()
+        cls.data_type1.delete()
+        cls.data_type2.delete()
+
+    def test_data_set_name_must_be_unique(self):
+        a = DataSet.objects.create(
+            name='foo',
+            data_group=self.data_group1,
+            data_type=self.data_type1)
+
         a.validate_unique()
 
-        b = DataSet(name='foo', data_group=datagroup1, data_type=datatype2)
+        b = DataSet(
+            name='foo',
+            data_group=self.data_group1,
+            data_type=self.data_type2)
+
         assert_raises(ValidationError, lambda: b.validate_unique())
 
     def test_data_group_data_type_combo_must_be_unique(self):
-        datagroup1 = DataGroup.objects.create(name='datagroup1')
-        datatype1 = DataType.objects.create(name='datatype1')
+        dataset1 = DataSet.objects.create(
+            name='dataset1',
+            data_group=self.data_group1,
+            data_type=self.data_type1)
 
-        dataset1 = DataSet.objects.create(name='dataset1',
-                                          data_group=datagroup1,
-                                          data_type=datatype1)
         dataset1.validate_unique()
 
-        dataset2 = DataSet(name='dataset2', data_group=datagroup1,
-                           data_type=datatype1)
+        dataset2 = DataSet(
+            name='dataset2',
+            data_group=self.data_group1,
+            data_type=self.data_type1)
         assert_raises(ValidationError, lambda: dataset2.validate_unique())
 
 
@@ -49,20 +66,30 @@ def test_character_not_allowed_in_name():
         yield _assert_name_not_valid, character * 10
 
 
+@contextmanager
+def _make_temp_data_group_and_type():
+    data_group = DataGroup.objects.create(name='tmp_data_group')
+    data_type = DataType.objects.create(name='tmp_data_type')
+
+    yield data_group, data_type
+
+    data_group.delete()
+    data_type.delete()
+
+
 def _assert_name_is_valid(name):
-    datagroup = DataGroup.objects.create(name='datagroup')
-    datatype = DataType.objects.create(name='datatype')
-    DataSet(name=name, data_group=datagroup, data_type=datatype).full_clean()
-    datagroup.delete()
-    datatype.delete()
+    with _make_temp_data_group_and_type() as (data_group, data_type):
+        DataSet(
+            name=name,
+            data_group=data_group,
+            data_type=data_type).full_clean()
 
 
 def _assert_name_not_valid(name):
-    datagroup = DataGroup.objects.create(name='datagroup')
-    datatype = DataType.objects.create(name='datatype')
-    assert_raises(
-        ValidationError,
-        lambda: DataSet(name=name, data_group=datagroup,
-                        data_type=datatype).full_clean())
-    datagroup.delete()
-    datatype.delete()
+    with _make_temp_data_group_and_type() as (data_group, data_type):
+        assert_raises(
+            ValidationError,
+            lambda: DataSet(
+                name=name,
+                data_group=data_group,
+                data_type=data_type).full_clean())


### PR DESCRIPTION
... in tests.

The temporary test database exists for duration of the whole test _file_
so its important that temporary things like data_types and data_groups
are cleaned up at the end of test group.

I factored this out into the setUpClass() and tearDownClass() methods
for the test classes, and a context manager for the function-tests.
