### PR TITLE
Unbreak the admin UI.

### DIFF
--- a/stagecraft/urls.py
+++ b/stagecraft/urls.py
@@ -6,7 +6,8 @@ from stagecraft.apps.datasets import views
 admin.autodiscover()
 
 urlpatterns = patterns(
-    url(r'^admin', include(admin.site.urls)),
+    '',
+    url(r'^admin/', include(admin.site.urls)),
     url(r'^data-sets$', views.list),
     url(r'^data-sets/(?P<name>\w+)$', views.detail),
 )


### PR DESCRIPTION
This commit broke it:
https://github.com/alphagov/stagecraft/commit/85eb15126523879912001dcbb85e2325d06234dc#diff-068e1bd61688ea7a4473670e86fc7613

This one fixes it.
