### PR TITLE
Clean up python bytecode fiels before tests

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -35,6 +35,11 @@ if [ -d "venv" ]; then
     source venv/bin/activate
 fi
 
+# clean up stray python bytecode
+find $basedir -iname '*.pyc' -exec rm {} \;
+find $basedir -iname '__pycache__' -exec rmdir {} \;
+
+
 #run unit tests
 python manage.py test --with-coverage --cover-package=datasets
 display_result $? 1 "Unit tests"


### PR DESCRIPTION
Because they can affect test output. For example when I changed branch
away to one which _didn't_ have some library code, the tests should have
failed (because they used the library code), but the library code .pyc
files were still kicking around.
