### PR TITLE
Remove preview and staging settings files

### DIFF
--- a/stagecraft/settings/preview.py
+++ b/stagecraft/settings/preview.py
@@ -1,3 +1,0 @@
-from .common import *
-
-DATABASES = load_databases_from_environment()

--- a/stagecraft/settings/staging.py
+++ b/stagecraft/settings/staging.py
@@ -1,1 +1,0 @@
-from .production import *


### PR DESCRIPTION
- Reduce the differences between production-like environments to reduce
  bugs that only exist in production.
- Make starting the app simpler in production-like environments.

@paulfurley you may have an opinion on this.
