### PR TITLE
Make the bearer token default to NULL

### DIFF
--- a/stagecraft/apps/datasets/models/data_set.py
+++ b/stagecraft/apps/datasets/models/data_set.py
@@ -31,7 +31,8 @@ class DataSet(models.Model):
     data_group = models.ForeignKey(DataGroup, on_delete=models.PROTECT)
     data_type = models.ForeignKey(DataType, on_delete=models.PROTECT)
     raw_queries_allowed = models.BooleanField(default=True)
-    bearer_token = models.CharField(max_length=255, blank=False, null=True)
+    bearer_token = models.CharField(max_length=255, blank=False, null=True,
+                                    default=None)  # None = can't use token
     upload_format = models.CharField(max_length=255, blank=True)
     upload_filters = models.TextField(blank=True)  # a comma delimited list
     auto_ids = models.TextField(blank=True)  # a comma delimited list


### PR DESCRIPTION
If we don't specify one then it should be disabled.

This didn't require a migration.
