### PR TITLE
Ensure that temporary test objects get cleaned up

### DIFF
--- a/stagecraft/apps/datasets/tests/models/test_data_set.py
+++ b/stagecraft/apps/datasets/tests/models/test_data_set.py
@@ -145,10 +145,11 @@ def _make_temp_data_group_and_type():
     data_group = DataGroup.objects.create(name='tmp_data_group')
     data_type = DataType.objects.create(name='tmp_data_type')
 
-    yield data_group, data_type
-
-    data_group.delete()
-    data_type.delete()
+    try:
+        yield data_group, data_type
+    finally:
+        data_group.delete()
+        data_type.delete()
 
 
 def _assert_name_is_valid(name):


### PR DESCRIPTION
When we're making temporary DataGroup and DataType objects in the tests,
it's important that we always clean them up after each test.

Otherwise the first failing test will leave them hanging around, then
subsequent tests fail with obscure integrity errors.
