### PR TITLE
Make blank/empty bearer token *mean* NULL

### DIFF
--- a/stagecraft/apps/datasets/migrations/0006_convert_null_bearer_token_to_blank.py
+++ b/stagecraft/apps/datasets/migrations/0006_convert_null_bearer_token_to_blank.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        "Write your forwards methods here."
+        # Note: Don't use "from appname.models import ModelName".
+        # Use orm.ModelName to refer to models in this application,
+        # and orm['appname.ModelName'] for models in other applications.
+        orm.DataSet.objects.filter(bearer_token=None).update(bearer_token='')
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+        orm.DataSet.objects.filter(bearer_token='').update(bearer_token=None)
+
+    models = {
+        u'datasets.datagroup': {
+            'Meta': {'object_name': 'DataGroup'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        u'datasets.dataset': {
+            'Meta': {'unique_together': "([u'data_group', u'data_type'],)", 'object_name': 'DataSet'},
+            'auto_ids': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'bearer_token': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'capped_size': ('django.db.models.fields.PositiveIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'data_group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['datasets.DataGroup']", 'on_delete': 'models.PROTECT'}),
+            'data_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['datasets.DataType']", 'on_delete': 'models.PROTECT'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'max_age_expected': ('django.db.models.fields.PositiveIntegerField', [], {'default': '86400', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'}),
+            'queryable': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'raw_queries_allowed': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'realtime': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'upload_filters': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'upload_format': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        u'datasets.datatype': {
+            'Meta': {'object_name': 'DataType'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'})
+        }
+    }
+
+    complete_apps = ['datasets']
+    symmetrical = True

--- a/stagecraft/apps/datasets/models/data_set.py
+++ b/stagecraft/apps/datasets/models/data_set.py
@@ -31,7 +31,8 @@ class DataSet(models.Model):
     data_group = models.ForeignKey(DataGroup, on_delete=models.PROTECT)
     data_type = models.ForeignKey(DataType, on_delete=models.PROTECT)
     raw_queries_allowed = models.BooleanField(default=True)
-    bearer_token = models.CharField(max_length=255, blank=False, null=True)
+    bearer_token = models.CharField(max_length=255, blank=True, null=False,
+                                    default="")  # "" = invalid token
     upload_format = models.CharField(max_length=255, blank=True)
     upload_filters = models.TextField(blank=True)  # a comma delimited list
     auto_ids = models.TextField(blank=True)  # a comma delimited list
@@ -46,12 +47,14 @@ class DataSet(models.Model):
         return "DataSet({})".format(self.name)
 
     def serialize(self):
+        token_or_null = self.bearer_token if self.bearer_token != '' else None
+
         return OrderedDict([
             ('name',                self.name),
             ('data_group',          self.data_group.name),
             ('data_type',           self.data_type.name),
             ('raw_queries_allowed', self.raw_queries_allowed),
-            ('bearer_token',        self.bearer_token),
+            ('bearer_token',        token_or_null),
             ('upload_format',       self.upload_format),
             ('upload_filters',      self.upload_filters),
             ('auto_ids',            self.auto_ids),

--- a/stagecraft/apps/datasets/tests/models/test_data_set.py
+++ b/stagecraft/apps/datasets/tests/models/test_data_set.py
@@ -7,7 +7,7 @@ import mock
 
 from contextlib import contextmanager
 
-from nose.tools import assert_raises
+from nose.tools import assert_raises, assert_equal
 
 from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from django.db.models.deletion import ProtectedError
@@ -129,6 +129,23 @@ class DataSetTestCase(TestCase):
 
         assert_raises(ProtectedError, lambda: refed_data_type.delete())
 
+    @mock.patch('stagecraft.apps.datasets.models.data_set.create_dataset')
+    def test_bearer_token_defaults_to_blank(self, mocked):
+        data_set = DataSet.objects.create(
+            name='data_set',
+            data_group=self.data_group1,
+            data_type=self.data_type1)
+        assert_equal('', data_set.bearer_token)
+
+    @mock.patch('stagecraft.apps.datasets.models.data_set.create_dataset')
+    def test_that_empty_bearer_token_serializes_to_null(self, mocked):
+        data_set = DataSet.objects.create(
+            name='data_set',
+            data_group=self.data_group1,
+            data_type=self.data_type1,
+            bearer_token='')
+        assert_equal(None, data_set.serialize()['bearer_token'])
+
 
 def test_character_allowed_in_name():
     for character in 'a1_-':
@@ -156,8 +173,7 @@ def _assert_name_is_valid(name):
         DataSet(
             name=name,
             data_group=data_group,
-            data_type=data_type,
-            bearer_token="example-token").full_clean()
+            data_type=data_type).full_clean()
 
 
 def _assert_name_not_valid(name):

--- a/stagecraft/apps/datasets/tests/views/test_data_set.py
+++ b/stagecraft/apps/datasets/tests/views/test_data_set.py
@@ -15,7 +15,7 @@ class DataSetsViewsTestCase(TestCase):
         assert_equal(resp.status_code, 200)
         expected = [
             {
-                'bearer_token': '',
+                'bearer_token': None,
                 'capped_size': None,
                 'name': 'set1',
                 'data_type': 'type1',
@@ -29,7 +29,7 @@ class DataSetsViewsTestCase(TestCase):
                 'raw_queries_allowed': True,
             },
             {
-                'bearer_token': '',
+                'bearer_token': None,
                 'capped_size': None,
                 'name': 'set2',
                 'data_type': 'type1',
@@ -50,7 +50,7 @@ class DataSetsViewsTestCase(TestCase):
         assert_equal(resp.status_code, 200)
         expected = [
             {
-                'bearer_token': '',
+                'bearer_token': None,
                 'capped_size': None,
                 'name': 'set1',
                 'data_type': 'type1',
@@ -82,7 +82,7 @@ class DataSetsViewsTestCase(TestCase):
         assert_equal(resp.status_code, 200)
         expected = [
             {
-                'bearer_token': '',
+                'bearer_token': None,
                 'capped_size': None,
                 'name': 'set1',
                 'data_type': 'type1',
@@ -96,7 +96,7 @@ class DataSetsViewsTestCase(TestCase):
                 'raw_queries_allowed': True,
             },
             {
-                'bearer_token': '',
+                'bearer_token': None,
                 'capped_size': None,
                 'name': 'set2',
                 'data_type': 'type1',
@@ -126,7 +126,7 @@ class DataSetsViewsTestCase(TestCase):
         resp = self.client.get('/data-sets/set1')
         assert_equal(resp.status_code, 200)
         expected = {
-            'bearer_token': '',
+            'bearer_token': None,
             'capped_size': None,
             'name': 'set1',
             'data_type': 'type1',


### PR DESCRIPTION
So it turns out that CharFields & NULL really don't work together, even
if you set null=true (see https://code.djangoproject.com/ticket/9590)

So the first change is a data migration to change any NULL bearer tokens
back to "" after previous commit which allowed NULL.

I've changed the `serialize()` method to interpret bearer_token of ""
as NULL. I've added tests and updated the view test so we are sure that
our backdrop endpoint will present NULL, not "".

I've tested the data migration by making a DataSet with a NULL bearer_token (on origin/master)

```
from stagecraft.apps.datasets.models import DataSet, DataGroup, DataType
group = DataGroup.objects.create(name='group')
type_=DataGroup.objects.create(name='type')
a = DataSet.objects.create(name='foo', data_group=group, data_type=type_, bearer_token=None)
```

Then checking out this branch and running the migration `0006_convert_null_bearer_token_to_blank`
