### PR TITLE
Run style tests before unit tests

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -39,11 +39,10 @@ fi
 find $basedir -iname '*.pyc' -exec rm {} \;
 find $basedir -iname '__pycache__' -exec rmdir {} \;
 
-
-#run unit tests
-python manage.py test --with-coverage --cover-package=datasets
-display_result $? 1 "Unit tests"
-
 # run style check
 $basedir/pep-it.sh | tee "$outdir/pep8.out"
 display_result $? 3 "Code style check"
+
+# run unit tests
+python manage.py test --with-coverage --cover-package=datasets
+display_result $? 1 "Unit tests"


### PR DESCRIPTION
Because:
- it's annoying to have to scroll back past style tests when looking at
  unit test output
- if the style test fails before running unit tests it's sufficiently
  annoying to encourage us to write PEP8 code from the start :)
