### PR TITLE
Don't Travis test release_* tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,6 @@ after_success:
 branches:
   except:
     - release
+    - /^release_\d+$/
 notifications:
   email: false


### PR DESCRIPTION
Because they are just tags pointing at commits on master that we've
already tested.
