### PR TITLE
Only create release tags for Python 2.7 job

### DIFF
--- a/.travis_scripts/push_release_tag.sh
+++ b/.travis_scripts/push_release_tag.sh
@@ -58,6 +58,13 @@ function ensure_running_in_travis_master_branch {
   fi
 }
 
+function ensure_only_tagging_on_production_python_version {
+  if [ "${TRAVIS_PYTHON_VERSION}" != "2.7" ]; then
+    echo "Not release tagging for Python version ${TRAVIS_PYTHON_VERSION}"
+    exit 3
+  fi
+}
+
 function make_temp_repo_directory {
   TMP_REPO_DIR=$(mktemp --directory --suffix _travis_${TRAVIS_BUILD_NUMBER})
 }
@@ -87,6 +94,7 @@ function setup_fake_travis_environment {
   TRAVIS_BRANCH="master"
   TRAVIS_COMMIT="3aed87b4f7bbb62e15fef65bd9a1b27d07d6e351"
   TRAVIS_BUILD_NUMBER="123456789"
+  TRAVIS_PYTHON_VERSION="2.7"
   GH_TOKEN="${TESTING_GITHUB_TOKEN}"
 }
 
@@ -100,6 +108,7 @@ fi
 
 
 ensure_running_in_travis_master_branch
+ensure_only_tagging_on_production_python_version
 make_temp_repo_directory
 clone_repo
 make_release_tag_from_travis_build_number


### PR DESCRIPTION
Create the release tag if the Python 2.7 job succeeds. Don't do anything
in the Python 3 job.

This is a bit of a workaround for the fact that there's no way of
running scripts after _all_ jobs complete on Travis. That means we end
up trying to release tag in every successful job.

See https://github.com/travis-ci/travis-ci/issues/929
