### PR TITLE
Remove py cache files in one go when testing

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -36,8 +36,8 @@ if [ -d "venv" ]; then
 fi
 
 # clean up stray python bytecode
-find $basedir -iname '*.pyc' -exec rm {} \;
-find $basedir -iname '__pycache__' -exec rmdir {} \;
+find $basedir -iname '*.pyc' -exec rm {} \+
+find $basedir -iname '__pycache__' -exec rmdir {} \+
 
 # run style check
 $basedir/pep-it.sh | tee "$outdir/pep8.out"


### PR DESCRIPTION
When running `run_tests.sh` on a Mac the second find exists with a
non-zero status (but successfully removes the directories) if an exec is
run per found directory. This change runs a single rmdir for all found
directories and does the same for the pyc files.
