### PR TITLE
Improve test for virtualenv in start-app.sh

### DIFF
--- a/start-app.sh
+++ b/start-app.sh
@@ -8,7 +8,7 @@
 
 VENV_DIR=~/.virtualenvs/stagecraft
 
-if [ ! -d "${VENV_DIR}" ]; then
+if [ ! -f "${VENV_DIR}/bin/activate" ]; then
     mkdir -p ${VENV_DIR}
     virtualenv --no-site-packages "$VENV_DIR"
 fi


### PR DESCRIPTION
Rather than looking for the `~/.virtualenvs/stagecraft/venv` directory, it
now looks for `~/.virtualenvs/stagecraft/venv/bin/activate` file.

This is to fix the case where virtualenv fails the first time and leaves
a dud directory around (it's happened a few times).
