### PR TITLE
Set the STATIC_ROOT setting, where assets will go

### DIFF
--- a/assets/.gitignore
+++ b/assets/.gitignore
@@ -1,0 +1,4 @@
+# Static files are collected into this directory.
+# They are source controlled elsewhere (ie in the app they originate from)
+
+.*

--- a/stagecraft/settings/common.py
+++ b/stagecraft/settings/common.py
@@ -95,3 +95,4 @@ TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 # https://docs.djangoproject.com/en/1.6/howto/static-files/
 
 STATIC_URL = '/static/'
+STATIC_ROOT = abspath(pjoin(BASE_DIR, 'assets'))


### PR DESCRIPTION
When we run `manage.py collectstatic` all static files (ie from admin)
will be collected up into this single place.

See https://docs.djangoproject.com/en/dev/howto/static-files/ and
https://docs.djangoproject.com/en/dev/howto/static-files/deployment/
