### PR TITLE
Default to using PostgreSQL in development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - pip install -r requirements/ci.txt --use-mirrors
 env:
   matrix:
-  - DJANGO_SETTINGS_MODULE=stagecraft.settings.ci SECRET_KEY=xyz DATABASE_URL=postgres://a:b@foo:999/db
+  - DJANGO_SETTINGS_MODULE=stagecraft.settings.ci SECRET_KEY=xyz DATABASE_URL=postgres://a:b@foo:999/db USE_SQLITE=true
   global:
     # NOTE: contains GH_TOKEN=xxx from github user gds-pp-ci
     secure: AnhgvS32/AMPi8rl9L9xh/2Xmt1459jXs13eiJI4kHtSGP/n2gkZtfKTiU9wezNqI5tVk4fYYltJNjvk5ZGkiEm/z5vpp8urRHUcGejZaa6ziyzFALpftuI5/5TF/dnlowQdFjh4Tcx4crZ1u5l4z5eJoxUSd4x9hk4d8/Tnjj8=

--- a/requirements/_common.txt
+++ b/requirements/_common.txt
@@ -4,3 +4,6 @@ django==1.6.1
 django-reversion==1.8.0
 South==0.8.4
 requests==2.2.1
+
+# psycopg2 requires the libpq-dev package
+psycopg2==2.5.2

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,7 +2,5 @@
 
 -r _common.txt
 
-# psycopg2 requires the libpq-dev package
-psycopg2==2.5.2
 gunicorn==18.0
 logstash_formatter==0.5.8

--- a/stagecraft/settings/development.py
+++ b/stagecraft/settings/development.py
@@ -39,12 +39,27 @@ MIDDLEWARE_CLASSES += (
 # Database
 # https://docs.djangoproject.com/en/1.6/ref/settings/#databases
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+if os.environ.get('USE_SQLITE', 'false') != 'false':
+    print("INFO: Using local SQLite database (USE_SQLITE=true)")
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        }
     }
-}
+else:
+    print("INFO: Using PostgreSQL database (USE_SQLITE=false)")
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'NAME': 'stagecraft',
+            'USER': 'stagecraft',
+            'PASSWORD': 'securem8',
+            'HOST': 'postgresql-primary',  # localhost
+            'PORT': '5432',
+        }
+    }
+
 
 BACKDROP_URL = 'http://localhost:3039'
 CREATE_COLLECTION_ENDPOINT_TOKEN = 'dev-create-endpoint-token'


### PR DESCRIPTION
Until now we've been using SQLITE as default (which has advantages, such as
being really easy to delete and access).

Constraints are enforced differently in PostgreSQL (ie at all) so we need to
start being able to use it ASAP, lest we run into problems on preview that we
haven't seen in development.

You can still use `USE_SQLITE=true|false` to switch the behaviour.
