### PR TITLE
Default to using PostgreSQL in development

### DIFF
--- a/stagecraft/settings/development.py
+++ b/stagecraft/settings/development.py
@@ -72,6 +72,14 @@ LOGGING = {
             'backupCount': 2,
             'formatter': 'standard',
         },
+        'database_log': {
+            'level': 'DEBUG',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': BASE_DIR + "/log/database_queries.log",
+            'maxBytes': 4 * 1024 * 1024,
+            'backupCount': 2,
+            'formatter': 'standard',
+        },
         'console': {
             'level': 'INFO',
             'class': 'logging.StreamHandler',
@@ -83,6 +91,12 @@ LOGGING = {
             'handlers': ['console', 'logfile'],
             'level': 'INFO',
             'propagate': True,  # also handle in parent handler
+        },
+
+        'django.db.backends': {
+            'handlers': ['database_log'],
+            'level': 'DEBUG',
+            'propagate': False,
         },
 
         'stagecraft.apps': {


### PR DESCRIPTION
Until now we've been using SQLITE as default (which has advantages, such as
being really easy to delete and access).

Constraints are enforced differently in PostgreSQL (ie at all) so we need to
start being able to use it ASAP, lest we run into problems on preview that we
haven't seen in development.

You can still use `USE_SQLITE=true|false` to switch the behaviour.
