### PR TITLE
Exec start-app.sh to avoid orphans

### DIFF
--- a/run_development.sh
+++ b/run_development.sh
@@ -6,4 +6,4 @@
 
 export DJANGO_SETTINGS_MODULE="stagecraft.settings.development"
 
-python manage.py runserver 0.0.0.0:${1-3204}
+exec python manage.py runserver 0.0.0.0:${1-3204}

--- a/start-app.sh
+++ b/start-app.sh
@@ -17,4 +17,4 @@ source "$VENV_DIR/bin/activate"
 
 pip install -r requirements/development.txt
 
-./run_development.sh $*
+exec ./run_development.sh $*


### PR DESCRIPTION
When foreman signals `start-app.sh`, children do not receive the message.
Instead the bash process running `start-app.sh` exits and the subprocess
becomes an orphan, getting reparented to init. The result is that servers
don't get stopped correctly and have to be killed manually which is an error
prone process.

This bug is related to alphagov/pp-development#48 and the fix in this commit
is necessary but not sufficient to close it.
