### PR TITLE
Allow all SlugField characters in /data-sets urls

### DIFF
--- a/stagecraft/apps/datasets/fixtures/datasets_testdata.json
+++ b/stagecraft/apps/datasets/fixtures/datasets_testdata.json
@@ -14,6 +14,13 @@
     }
 },
 {
+    "pk": 3, 
+    "model": "datasets.datagroup", 
+    "fields": {
+        "name": "group3"
+    }
+},
+{
     "pk": 1, 
     "model": "datasets.datatype", 
     "fields": {
@@ -25,6 +32,13 @@
     "model": "datasets.datatype", 
     "fields": {
         "name": "type2"
+    }
+},
+{
+    "pk": 3, 
+    "model": "datasets.datatype", 
+    "fields": {
+        "name": "type3"
     }
 },
 {
@@ -62,5 +76,24 @@
         "upload_format": "", 
         "raw_queries_allowed": true
     }
+},
+{
+    "pk": 3, 
+    "model": "datasets.dataset", 
+    "fields": {
+        "bearer_token": "", 
+        "capped_size": null, 
+        "name": "abc_-0123456789", 
+        "data_type": 3, 
+        "realtime": false, 
+        "auto_ids": "", 
+        "max_age_expected": 86400, 
+        "data_group": 3, 
+        "upload_filters": "", 
+        "queryable": true, 
+        "upload_format": "", 
+        "raw_queries_allowed": true
+    }
 }
+
 ]

--- a/stagecraft/apps/datasets/tests/views/test_data_set.py
+++ b/stagecraft/apps/datasets/tests/views/test_data_set.py
@@ -85,6 +85,20 @@ class DataSetsViewsTestCase(TestCase):
                 'upload_format': '',
                 'raw_queries_allowed': True,
             },
+            {
+                'name': 'abc_-0123456789',
+                'data_group': 'group3',
+                'data_type': 'type3',
+                'bearer_token': None,
+                'capped_size': None,
+                'realtime': False,
+                'auto_ids': '',
+                'max_age_expected': 86400,
+                'upload_filters': '',
+                'queryable': True,
+                'upload_format': '',
+                'raw_queries_allowed': True,
+            },
         ]
         assert_equal(json.loads(resp.content.decode('utf-8')), expected)
 
@@ -195,6 +209,27 @@ class DataSetsViewsTestCase(TestCase):
             'auto_ids': '',
             'max_age_expected': 86400,
             'data_group': 'group1',
+            'upload_filters': '',
+            'queryable': True,
+            'upload_format': '',
+            'raw_queries_allowed': True,
+        }
+        assert_equal(json.loads(resp.content.decode('utf-8')), expected)
+
+    def test_detail_works_with_all_slugfield_characters(self):
+        resp = self.client.get(
+            '/data-sets/abc_-0123456789',
+            HTTP_AUTHORIZATION='Nearer dev-data-set-query-token')
+        assert_equal(resp.status_code, 200)
+        expected = {
+            'name': 'abc_-0123456789',
+            'data_group': 'group3',
+            'data_type': 'type3',
+            'bearer_token': None,
+            'capped_size': None,
+            'realtime': False,
+            'auto_ids': '',
+            'max_age_expected': 86400,
             'upload_filters': '',
             'queryable': True,
             'upload_format': '',

--- a/stagecraft/urls.py
+++ b/stagecraft/urls.py
@@ -11,7 +11,7 @@ urlpatterns = patterns(
     url(r'^admin/', include(admin.site.urls)),
     # Note that the query string params get transparently passed to the view
     url(r'^data-sets$', datasets_views.list),
-    url(r'^data-sets/(?P<name>\w+)$', datasets_views.detail),
+    url(r'^data-sets/(?P<name>[\w-]+)$', datasets_views.detail),
 
     url(r'^_status$', status_views.status),
 )


### PR DESCRIPTION
`\w` matches underscores but not hyphens. `[\w-]` matches both.

See http://stackoverflow.com/a/5718037 and http://regex101.com/r/uN6pP0

See https://www.pivotaltracker.com/story/show/66670412
[Fixes #66670412]
