### PR TITLE
Only clean up py files inside stagecraft/

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -36,8 +36,8 @@ if [ -d "venv" ]; then
 fi
 
 # clean up stray python bytecode
-find $basedir -iname '*.pyc' -exec rm {} \+
-find $basedir -iname '__pycache__' -exec rmdir {} \+
+find $basedir/stagecraft -iname '*.pyc' -exec rm {} \+
+find $basedir/stagecraft -iname '__pycache__' -exec rmdir {} \+
 
 # run style check
 $basedir/pep-it.sh | tee "$outdir/pep8.out"


### PR DESCRIPTION
Before we run tests, we clean up python bytecode files. We should only do
this inside the django project, otherwise we traverse the venv/ and other
directories which is a waste of time.
