### PR TITLE
Fix order when getting data-sets on Postgres

### DIFF
--- a/stagecraft/apps/datasets/views/data_set.py
+++ b/stagecraft/apps/datasets/views/data_set.py
@@ -87,7 +87,7 @@ def list(request, data_group=None, data_type=None):
         return HttpResponseBadRequest(to_json(error))
 
     filter_kwargs = get_filter_kwargs(key_map, request.GET.items())
-    data_sets = DataSet.objects.filter(**filter_kwargs)
+    data_sets = DataSet.objects.filter(**filter_kwargs).order_by('pk')
     json_str = to_json([ds.serialize() for ds in data_sets])
 
     return HttpResponse(json_str, content_type='application/json')


### PR DESCRIPTION
The unit tests fail when USE_SQLITE is not true because the order of the rows returned from the data-set list view is different to those expected. Ordering the results by the primary key fixes this.
