### PR TITLE
Redirect the defunct index/ to index/admin/

### DIFF
--- a/stagecraft/urls.py
+++ b/stagecraft/urls.py
@@ -9,6 +9,9 @@ admin.autodiscover()
 
 urlpatterns = patterns(
     '',
+    # Redirect / to /admin/ using a view reference
+    # http://bit.ly/1qkuGZ0
+    url(r'^$', RedirectView.as_view(pattern_name='admin:index')),
     url(r'^admin/', include(admin.site.urls)),
     # Note that the query string params get transparently passed to the view
     url(r'^data-sets$', datasets_views.list, name='data-sets-list'),


### PR DESCRIPTION
LOOK:

![](http://24.media.tumblr.com/88b53cd8b9d251a515819b4ab52fc778/tumblr_mzhgete9y71r3gb3zo1_250.gif)
- Use a view redirect
- Seeing as `/` doesn't do anything, for convenience, redirect it to the admin app
