### PR TITLE
Order data groups/sets/types by name by default.

### DIFF
--- a/stagecraft/apps/datasets/models/data_group.py
+++ b/stagecraft/apps/datasets/models/data_group.py
@@ -12,3 +12,4 @@ class DataGroup(models.Model):
 
     class Meta:
         app_label = 'datasets'
+        ordering = ['name']

--- a/stagecraft/apps/datasets/models/data_set.py
+++ b/stagecraft/apps/datasets/models/data_set.py
@@ -129,3 +129,4 @@ class DataSet(models.Model):
     class Meta:
         app_label = 'datasets'
         unique_together = ['data_group', 'data_type']
+        ordering = ['name']

--- a/stagecraft/apps/datasets/models/data_type.py
+++ b/stagecraft/apps/datasets/models/data_type.py
@@ -12,3 +12,4 @@ class DataType(models.Model):
 
     class Meta:
         app_label = 'datasets'
+        ordering = ['name']


### PR DESCRIPTION
As a Stagecraft user
I would like data groups, sets and types to be ordered alphabetically
by name in the admin interface
So that they are easy for me to find quickly in dropdown lists.
