### PR TITLE
Add dataset count to data group/data type admin lists.

### DIFF
--- a/stagecraft/apps/datasets/admin/data_group.py
+++ b/stagecraft/apps/datasets/admin/data_group.py
@@ -1,10 +1,23 @@
 from __future__ import unicode_literals
 from django.contrib import admin
+from django.db import models
 import reversion
 from stagecraft.apps.datasets.models.data_group import DataGroup
+from stagecraft.apps.datasets.models.data_set import DataSet
 
 
 class DataGroupAdmin(reversion.VersionAdmin):
     search_fields = ['name']
+    list_display = ('name', 'number_of_datasets',)
+
+    def queryset(self, request):
+        qs = super(DataGroupAdmin, self).queryset(request)
+        qs = qs.annotate(models.Count('dataset'))
+        return qs
+
+    def number_of_datasets(self, obj):
+        return obj.dataset__count
+
+    number_of_datasets.admin_order_field = 'dataset__count'
 
 admin.site.register(DataGroup, DataGroupAdmin)

--- a/stagecraft/apps/datasets/admin/data_type.py
+++ b/stagecraft/apps/datasets/admin/data_type.py
@@ -1,10 +1,23 @@
 from __future__ import unicode_literals
 from django.contrib import admin
+from django.db import models
 import reversion
 from stagecraft.apps.datasets.models.data_type import DataType
+from stagecraft.apps.datasets.models.data_set import DataSet
 
 
 class DataTypeAdmin(reversion.VersionAdmin):
     search_fields = ['name']
+    list_display = ('name', 'number_of_datasets',)
+
+    def queryset(self, request):
+        qs = super(DataTypeAdmin, self).queryset(request)
+        qs = qs.annotate(models.Count('dataset'))
+        return qs
+
+    def number_of_datasets(self, obj):
+        return obj.dataset__count
+
+    number_of_datasets.admin_order_field = 'dataset__count'
 
 admin.site.register(DataType, DataTypeAdmin)


### PR DESCRIPTION
When browsing data groups and data types, it's helpful to be
able to see how many data sets each one has associated with
it.

Add this to the Django admin list display for data groups and
data types.

This creates a sortable column in the admin, so users can sort
it to find the most and least popular data groups and data types.
