### PR TITLE
Show list of attached datasets on data group/type admin pages.

### DIFF
--- a/stagecraft/apps/datasets/admin/data_group.py
+++ b/stagecraft/apps/datasets/admin/data_group.py
@@ -6,9 +6,22 @@ from stagecraft.apps.datasets.models.data_group import DataGroup
 from stagecraft.apps.datasets.models.data_set import DataSet
 
 
+class DataSetInline(admin.StackedInline):
+    model = DataSet
+    fields = ('name', 'data_type',)
+    readonly_fields = ('name', 'data_type',)
+    extra = 0
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
 class DataGroupAdmin(reversion.VersionAdmin):
     search_fields = ['name']
     list_display = ('name', 'number_of_datasets',)
+    inlines = [
+        DataSetInline
+    ]
 
     def queryset(self, request):
         qs = super(DataGroupAdmin, self).queryset(request)

--- a/stagecraft/apps/datasets/admin/data_type.py
+++ b/stagecraft/apps/datasets/admin/data_type.py
@@ -6,9 +6,22 @@ from stagecraft.apps.datasets.models.data_type import DataType
 from stagecraft.apps.datasets.models.data_set import DataSet
 
 
+class DataSetInline(admin.StackedInline):
+    model = DataSet
+    fields = ('name', 'data_group',)
+    readonly_fields = ('name', 'data_group',)
+    extra = 0
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
 class DataTypeAdmin(reversion.VersionAdmin):
     search_fields = ['name']
     list_display = ('name', 'number_of_datasets',)
+    inlines = [
+        DataSetInline
+    ]
 
     def queryset(self, request):
         qs = super(DataTypeAdmin, self).queryset(request)


### PR DESCRIPTION
Use admin.StackedInline to show a list of attached datasets on
admin pages for datagroups and datatypes.

These are read-only, and datasets cannot be deleted from these
pages. However, new datasets can be added here - we can disable
this if we want.
