### PR TITLE
[#69449916] Removes raw queries from data-set form

### DIFF
--- a/stagecraft/apps/datasets/models/data_set.py
+++ b/stagecraft/apps/datasets/models/data_set.py
@@ -38,7 +38,7 @@ class DataSet(models.Model):
 
     data_group = models.ForeignKey(DataGroup, on_delete=models.PROTECT)
     data_type = models.ForeignKey(DataType, on_delete=models.PROTECT)
-    raw_queries_allowed = models.BooleanField(default=True)
+    raw_queries_allowed = models.BooleanField(default=True, editable=False)
     bearer_token = models.CharField(max_length=255, blank=True, null=False,
                                     default="")  # "" = invalid token
     upload_format = models.CharField(max_length=255, blank=True)


### PR DESCRIPTION
- Uses `editable=False` flag at the model level.
- This will mean all data-sets will default to `True`, and will not be modifiable via the admin interface.

Sorted:
![](http://37.media.tumblr.com/cdf9c5d8e3620b7ab6258317572a0120/tumblr_n3oti0ntUL1qdlh1io1_400.gif)
