### PR TITLE
Use X-Forwarded-Proto to determine is_secure

### DIFF
--- a/stagecraft/settings/common.py
+++ b/stagecraft/settings/common.py
@@ -30,6 +30,7 @@ TEMPLATE_DEBUG = False
 ALLOWED_HOSTS = []
 
 USE_X_FORWARDED_HOST = True
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 
 def load_databases_from_environment():


### PR DESCRIPTION
Use the X-Forwarded-Proto header to determine whether the request is
secure or not. This allows Stagecraft to correctly generate URLs to
itself.
https://docs.djangoproject.com/en/1.5/ref/settings/#secure-proxy-ssl-header
