### PR TITLE
Automatically run migrations in development

### DIFF
--- a/run_development.sh
+++ b/run_development.sh
@@ -6,4 +6,6 @@
 
 export DJANGO_SETTINGS_MODULE="stagecraft.settings.development"
 
+python manage.py syncdb --migrate --noinput
+
 exec python manage.py runserver 0.0.0.0:${1-3204}


### PR DESCRIPTION
So that when someone does `bowl stagecraft` for the first time, they 
automatically get a database (albeit a totally empty one).

https://www.pivotaltracker.com/story/show/68997642

[#68997642]
