### PR TITLE
Improve error messages shown from Backdrop

### DIFF
--- a/stagecraft/apps/datasets/admin/data_set.py
+++ b/stagecraft/apps/datasets/admin/data_set.py
@@ -78,8 +78,7 @@ class DataSetAdmin(reversion.VersionAdmin):
             return super(DataSetAdmin, self).response_add(
                 request, obj, *args, **kwargs)
 
-        messages.error(request, "Failed to create: {}".format(
-            repr(self.exception)))
+        messages.error(request, str(self.exception))
         return self.response_post_save_add(request, obj)
 
     def response_change(self, request, obj, *args, **kwargs):
@@ -91,8 +90,7 @@ class DataSetAdmin(reversion.VersionAdmin):
             return super(DataSetAdmin, self).response_change(
                 request, obj, *args, **kwargs)
 
-        messages.error(request, "Failed to modify: {}".format(
-            repr(self.exception)))
+        messages.error(request, str(self.exception))
         return self.response_post_save_change(request, obj)
 
     search_fields = ['name']


### PR DESCRIPTION
- Handle previously uncaught `ConnectionError`
- Make 4 new subclasses of Backdrop error:
  - BackdropAuthenticationError
  - BackdropConnectionError
  - BackdropBadRequestError
  - BackdropUnknownError
- Factor out the function which sends & handles errors so it's common
  between create & delete requests.
- Extract and use the error message from the Backdrop response JSON if
  available.

https://www.pivotaltracker.com/story/show/65645322

[Delivers #65645322]
