### PR TITLE
Fix backdrop_client disabled checking

### DIFF
--- a/stagecraft/libs/backdrop_client/backdrop_client.py
+++ b/stagecraft/libs/backdrop_client/backdrop_client.py
@@ -65,6 +65,8 @@ def check_disabled(func):
     def _check(*args, **kwargs):
         if _DISABLED:
             return
+        else:
+            return func(*args, **kwargs)
     return _check
 
 


### PR DESCRIPTION
The neat little @check_backdrop decorator was never actually calling the 
wrapped function :)
