### PR TITLE
Catch backdrop exceptions and display in admin UI

### DIFF
--- a/stagecraft/apps/datasets/admin/data_set.py
+++ b/stagecraft/apps/datasets/admin/data_set.py
@@ -22,11 +22,10 @@ class DataSetAdmin(reversion.VersionAdmin):
       - are used by VersionAdmin to create revision
       - we are overriding here to stop a revision if the model fails to save
 
-    `response_add` and `response_change` methods:
-      - by default in the base class they generate a success message
-      - we are overriding here to generate a different message
-        if the model fails to save
-
+    `changelist_view` method:
+      - is the view where you see a list of datasets, which you are
+      redirected to after deletion and add and change, so is a good place for
+      showing error messages
     """
 
     class Media:
@@ -37,7 +36,7 @@ class DataSetAdmin(reversion.VersionAdmin):
 
     def __init__(self, *args, **kwargs):
         super(DataSetAdmin, self).__init__(*args, **kwargs)
-        self.successful_save = False
+        self.successful_save = None
         self.exception = None
 
     # Get fields that are only editable on creation
@@ -48,8 +47,23 @@ class DataSetAdmin(reversion.VersionAdmin):
             return set()
 
     def save_model(self, request, *args, **kwargs):
+        self._try_change_model(
+            lambda: super(DataSetAdmin, self).save_model(
+                request, *args, **kwargs))
+
+    def delete_model(self, request, obj, *args, **kwargs):
+        self._try_change_model(
+            lambda: super(DataSetAdmin, self).delete_model(
+                request, obj, *args, **kwargs))
+
+    def _try_change_model(self, model_func):
+        """
+        If an external Backdrop exception happens when changing the model,
+        store the exception for later use by the log_ methods and the
+        changelist_view.
+        """
         try:
-            super(DataSetAdmin, self).save_model(request, *args, **kwargs)
+            model_func()
         except BackdropError as e:
             self.successful_save = False
             logger.exception(e)
@@ -69,31 +83,35 @@ class DataSetAdmin(reversion.VersionAdmin):
         else:
             logger.warning("save(..) failed, blocking log_change(..)")
 
-    def response_add(self, request, obj, *args, **kwargs):
-        """
-        Generate the HTTP response for an add action.
-        """
+    def log_deletion(self, *args, **kwargs):
         if self.successful_save is True:
-            # The base response_add() emits an appropriate success message
-            return super(DataSetAdmin, self).response_add(
-                request, obj, *args, **kwargs)
+            super(DataSetAdmin, self).log_deletion(*args, **kwargs)
+        else:
+            logger.warning("save(..) failed, blocking log_deletion(..)")
 
-        messages.error(request, str(self.exception))
-        return self.response_post_save_add(request, obj)
-
-    def response_change(self, request, obj, *args, **kwargs):
+    def changelist_view(self, request, *args, **kwargs):
         """
-        Generate the HTTP response for a save action.
+        Base admin class method override. Despite the name, this is the main
+        list view
         """
-        if self.successful_save is True:
-            # The base response_change() emits an appropriate success message
-            return super(DataSetAdmin, self).response_change(
-                request, obj, *args, **kwargs)
-
-        messages.error(request, str(self.exception))
-        return self.response_post_save_change(request, obj)
+        if self.successful_save is False:
+            _clear_most_recent_message(request)
+            messages.error(request, str(self.exception))
+        return super(DataSetAdmin, self).changelist_view(
+            request, *args, **kwargs)
 
     search_fields = ['name']
     list_display = ('name', 'data_group', 'data_type', 'data_location')
+
+
+def _clear_most_recent_message(request):
+    storage = messages.get_messages(request)
+    # Calling __iter__() causes messages to be transferred from
+    # storage._queued_messages to storage._loaded_messages. See
+    # django.contrib.messages.storage.base:BaseStorage
+
+    storage.__iter__()
+    if len(storage) > 0:
+        storage._loaded_messages.pop(-1)
 
 admin.site.register(DataSet, DataSetAdmin)


### PR DESCRIPTION
- Change approach of using response_add and response_change to
  changelist_view which covers all scenarios
- New approach is to delete the success message from the django
  messages queue rather than intercepting it. Because django 1.6 does
  not allow intercpeting the delete success message. django 1.7 does
  support this however if we upgrade. http://stackoverflow.com/a/18289950
- Override log_deletion and delete_model as per existing add and
  change
- Factor out backdrop exception handler to support both save_model and
  delete_model
