### PR TITLE
Remove data_sets from backdrop user search. Fixes #71337688

### DIFF
--- a/stagecraft/apps/datasets/admin/backdrop_user.py
+++ b/stagecraft/apps/datasets/admin/backdrop_user.py
@@ -13,7 +13,7 @@ class DataSetInline(admin.StackedInline):
 
 
 class BackdropUserAdmin(reversion.VersionAdmin):
-    search_fields = ['email', 'data_sets']
+    search_fields = ['email']
     list_display = ('email', 'numer_of_datasets_user_has_access_to',)
     list_per_page = 30
 


### PR DESCRIPTION
- This fixes backdrop user search on the admin list view
- Before it was trying to search through data_sets as well, which requires more prodding around to make work
