### PR TITLE
Make datasets an optional field on backdrop users model. Fixes #71336920

### DIFF
--- a/stagecraft/apps/datasets/models/backdrop_user.py
+++ b/stagecraft/apps/datasets/models/backdrop_user.py
@@ -21,7 +21,7 @@ class BackdropUser(models.Model):
         help_text=""""""
     )
 
-    data_sets = models.ManyToManyField(DataSet)
+    data_sets = models.ManyToManyField(DataSet, blank=True)
 
     def serialize(self):
         def get_names(data_sets):


### PR DESCRIPTION
- This means an admin should be able to remove access to all data-sets for a backdrop user, but not have to delete the backdrop user in order to do so.
