### PR TITLE
Add filter_horizontal to backdrop user admin

### DIFF
--- a/stagecraft/apps/datasets/admin/backdrop_user.py
+++ b/stagecraft/apps/datasets/admin/backdrop_user.py
@@ -16,6 +16,7 @@ class BackdropUserAdmin(reversion.VersionAdmin):
     search_fields = ['email', 'data_sets']
     list_display = ('email', 'numer_of_datasets_user_has_access_to',)
     list_per_page = 30
+    filter_horizontal = ('data_sets',)
 
     def queryset(self, request):
         return BackdropUser.objects.annotate(


### PR DESCRIPTION
- Provides a much more usable interface to filter and add data_sets for backdrop admin users

Looks something like:

![](http://www.djangobook.com/en/2.0/_images/book_editform1.png)
