### PR TITLE
Handle HTTP 404 from Backdrop as a pretty error

### DIFF
--- a/stagecraft/libs/backdrop_client/backdrop_client.py
+++ b/stagecraft/libs/backdrop_client/backdrop_client.py
@@ -42,6 +42,12 @@ class BackdropBadRequestError(BackdropError):
             super(BackdropBadRequestError, self).__str__())
 
 
+class BackdropNotFoundError(BackdropError):
+    def __str__(self):
+        return 'Not found in Backdrop: {}'.format(
+            super(BackdropNotFoundError, self).__str__())
+
+
 @contextmanager
 def backdrop_connection_disabled():
     """
@@ -147,6 +153,9 @@ def _send_backdrop_request(backdrop_request):
 
         if response.status_code == 400:
             raise BackdropBadRequestError(error_message)
+
+        elif response.status_code == 404:
+            raise BackdropNotFoundError(error_message)
 
         elif response.status_code in (401, 403):
             raise BackdropAuthenticationError(error_message)


### PR DESCRIPTION
We handle other status codes, but not 404. This makes 404s prettier.
