### PR TITLE
Upgrade django to 1.6.5

### DIFF
--- a/requirements/_common.txt
+++ b/requirements/_common.txt
@@ -1,6 +1,6 @@
 # requirements/common.txt: Used on *all* environments.
 
-django==1.6.2
+django==1.6.5
 django-reversion==1.8.0
 South==0.8.4
 requests==2.2.1


### PR DESCRIPTION
The primary motivation for this upgrade is CVE-2014-0472
http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-0472

"The django.core.urlresolvers.reverse function in Django before 1.4.11,
1.5.x before 1.5.6, 1.6.x before 1.6.3, and 1.7.x before 1.7 beta 2
allows remote attackers to import and execute arbitrary Python modules
by leveraging a view that constructs URLs using user input and a "dotted
Python path.""
