### PR TITLE
[BUGFIX] Disable bulk delete on data sets

### DIFF
--- a/stagecraft/apps/datasets/admin/data_set.py
+++ b/stagecraft/apps/datasets/admin/data_set.py
@@ -29,6 +29,8 @@ class DataSetAdmin(reversion.VersionAdmin):
 
     """
 
+    actions = None
+
     class Media:
         css = {
             "all": ("admin/css/datasets.css",),


### PR DESCRIPTION
[Fixes #71387092]
https://www.pivotaltracker.com/story/show/71387092

Given the dependency between stagecraft and backdrop, bulk deletion
raises a lot of difficult problems. It has been decided that we don't
actually need bulk deletion so this change removes the feature from the
admin UI.
