### PR TITLE
Change the 'data_location' link to limit 10

### DIFF
--- a/stagecraft/apps/datasets/models/data_set.py
+++ b/stagecraft/apps/datasets/models/data_set.py
@@ -189,7 +189,7 @@ class DataSet(models.Model):
             backdrop_url=settings.BACKDROP_URL,
             data_group=self.data_group,
             data_type=self.data_type)
-        return '<a href="{0}">{0}</a>'.format(path)
+        return '<a href="{0}?limit=10">{0}</a>'.format(path)
     data_location.allow_tags = True
 
     def serialize(self):


### PR DESCRIPTION
![](http://www.reactiongifs.com/r/powerrangers.gif)
- getting the entirety of a data-set and spitting it out into the browser was killing chrome for me
- I think 10 is probably a good sample size, and hopefully people will know how to change the limit in the url
