### PR TITLE
Add description text field to data-type model

### DIFF
--- a/stagecraft/apps/datasets/migrations/0011_auto__add_field_datatype_description.py
+++ b/stagecraft/apps/datasets/migrations/0011_auto__add_field_datatype_description.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'DataType.description'
+        db.add_column(u'datasets_datatype', 'description',
+                      self.gf('django.db.models.fields.TextField')(default='', blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'DataType.description'
+        db.delete_column(u'datasets_datatype', 'description')
+
+
+    models = {
+        u'datasets.backdropuser': {
+            'Meta': {'ordering': "[u'email']", 'object_name': 'BackdropUser'},
+            'data_sets': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['datasets.DataSet']", 'symmetrical': 'False', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'unique': 'True', 'max_length': '254'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'datasets.datagroup': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'DataGroup'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        u'datasets.dataset': {
+            'Meta': {'ordering': "[u'name']", 'unique_together': "([u'data_group', u'data_type'],)", 'object_name': 'DataSet'},
+            'auto_ids': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'bearer_token': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'capped_size': ('django.db.models.fields.PositiveIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'data_group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['datasets.DataGroup']", 'on_delete': 'models.PROTECT'}),
+            'data_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['datasets.DataType']", 'on_delete': 'models.PROTECT'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'max_age_expected': ('django.db.models.fields.PositiveIntegerField', [], {'default': '86400', 'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '200'}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'queryable': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'raw_queries_allowed': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'realtime': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'upload_filters': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'upload_format': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        u'datasets.datatype': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'DataType'},
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'})
+        }
+    }
+
+    complete_apps = ['datasets']

--- a/stagecraft/apps/datasets/models/data_type.py
+++ b/stagecraft/apps/datasets/models/data_type.py
@@ -9,6 +9,7 @@ from ..helpers.validators import data_type_name_validator
 class DataType(models.Model):
     name = models.SlugField(max_length=50, unique=True,
                             validators=[data_type_name_validator])
+    description = models.TextField(blank=True)
 
     def __str__(self):
         return "{}".format(self.name)


### PR DESCRIPTION
A human readable description in the meta data for each data-type should help
users know what they're for.
