### PR TITLE
Remove caching from long_cache endpoints

### DIFF
--- a/stagecraft/apps/datasets/tests/views/test_backdrop_user.py
+++ b/stagecraft/apps/datasets/tests/views/test_backdrop_user.py
@@ -11,11 +11,11 @@ from stagecraft.apps.datasets.tests.support.test_helpers import (
 
 
 class LongCacheTestCase(TestCase):
-    def test_detail_sets_long_cache_headers(self):
+    def test_detail_sets_cache_headers(self):
         resp = self.client.get(
             '/data-sets/set1',
             HTTP_AUTHORIZATION='Bearer development-oauth-access-token')
-        assert_that(resp, has_header('Cache-Control', 'max-age=31536000'))
+        assert_that(resp, has_header('Cache-Control', 'max-age=0'))
         assert_that(resp, has_header('Vary', 'Authorization'))
 
 

--- a/stagecraft/apps/datasets/tests/views/test_utils.py
+++ b/stagecraft/apps/datasets/tests/views/test_utils.py
@@ -66,14 +66,14 @@ class CheckPermissionTestCase(TestCase):
 class LongCacheTestCase(TestCase):
     fixtures = ['datasets_testdata.json']
 
-    def test_list_sets_long_cache_headers(self):
+    def test_list_sets_cache_headers(self):
         resp = self.client.get(
             '/data-sets',
             HTTP_AUTHORIZATION='Bearer development-oauth-access-token')
-        assert_that(resp, has_header('Cache-Control', 'max-age=31536000'))
+        assert_that(resp, has_header('Cache-Control', 'max-age=0'))
 
-    def test_detail_sets_long_cache_headers(self):
+    def test_detail_sets_cache_headers(self):
         resp = self.client.get(
             '/data-sets/set1',
             HTTP_AUTHORIZATION='Bearer development-oauth-access-token')
-        assert_that(resp, has_header('Cache-Control', 'max-age=31536000'))
+        assert_that(resp, has_header('Cache-Control', 'max-age=0'))

--- a/stagecraft/apps/datasets/views/backdrop_user.py
+++ b/stagecraft/apps/datasets/views/backdrop_user.py
@@ -3,6 +3,7 @@ import logging
 
 from django.conf import settings
 from django.http import (HttpResponse, HttpResponseNotFound)
+from django.views.decorators.cache import never_cache
 from django.views.decorators.vary import vary_on_headers
 
 from stagecraft.apps.datasets.models import BackdropUser
@@ -11,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 @permission_required('user')
-@long_cache
+@never_cache
 @vary_on_headers('Authorization')
 def detail(user, request, email):
     try:

--- a/stagecraft/apps/datasets/views/data_set.py
+++ b/stagecraft/apps/datasets/views/data_set.py
@@ -4,6 +4,7 @@ import logging
 from django.conf import settings
 from django.http import (HttpResponse, HttpResponseBadRequest,
                          HttpResponseNotFound)
+from django.views.decorators.cache import never_cache
 from django.views.decorators.vary import vary_on_headers
 
 from stagecraft.apps.datasets.models import DataSet, BackdropUser
@@ -12,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 @permission_required('signin')
-@long_cache
+@never_cache
 @vary_on_headers('Authorization')
 def detail(user, request, name):
     try:
@@ -36,7 +37,7 @@ def detail(user, request, name):
 
 
 @permission_required('signin')
-@long_cache
+@never_cache
 @vary_on_headers('Authorization')
 def list(user, request, data_group=None, data_type=None):
     def get_filter_kwargs(key_map, query_params):


### PR DESCRIPTION
These cache headers were introduced for resiliency. We're going to achieve that by adding a PostgreSQL slave instead.

We need the most up to date information to be available when clients are checking user access and authentication with Stagecraft.
