### PR TITLE
Remove backdrop dependency for data set creation

### DIFF
--- a/stagecraft/apps/datasets/management/commands/import_from_backdrop.py
+++ b/stagecraft/apps/datasets/management/commands/import_from_backdrop.py
@@ -9,7 +9,6 @@ from django.db import transaction
 from django.core.management.base import BaseCommand, CommandError
 
 from stagecraft.apps.datasets.models import DataSet, DataGroup, DataType
-from stagecraft.libs.backdrop_client import backdrop_connection_disabled
 
 
 class Command(BaseCommand):
@@ -35,8 +34,7 @@ class Command(BaseCommand):
 
             if options['without_backdrop']:
                 self.stdout.write("Disabling Backdrop")
-                with backdrop_connection_disabled():
-                    self.load_data_sets_from_data_sets_json(filename)
+                self.load_data_sets_from_data_sets_json(filename)
             else:
                 self.stdout.write("Not disabling Backdrop")
                 self.load_data_sets_from_data_sets_json(filename)
@@ -56,7 +54,7 @@ class Command(BaseCommand):
             return
 
         with transaction.atomic(), reversion.create_revision():
-            #self.stdout.write("Creating DataSet from:\n{}".format(data_set))
+            # self.stdout.write("Creating DataSet from:\n{}".format(data_set))
             DataSet.objects.create(
                 name=name,
                 data_group=self.get_or_create(

--- a/stagecraft/apps/datasets/models/data_set.py
+++ b/stagecraft/apps/datasets/models/data_set.py
@@ -13,7 +13,7 @@ from django.utils.encoding import python_2_unicode_compatible
 from stagecraft.apps.datasets.models.data_group import DataGroup
 from stagecraft.apps.datasets.models.data_type import DataType
 
-from stagecraft.libs.backdrop_client import (create_data_set, delete_data_set,
+from stagecraft.libs.backdrop_client import (delete_data_set,
                                              BackdropNotFoundError)
 from stagecraft.libs.schemas import get_schema
 
@@ -256,12 +256,6 @@ class DataSet(models.Model):
         if is_new:
             self.name = self.generate_data_set_name()
         super(DataSet, self).save(*args, **kwargs)
-
-        if is_new:
-            size_bytes = self.capped_size if self.is_capped else 0
-            # Backdrop can't be rolled back dude.
-            # Ensure this is the final action of the save method.
-            create_data_set(self.name, size_bytes)
 
     def generate_data_set_name(self):
         return '_'.join((self.data_group.name,

--- a/stagecraft/apps/datasets/tests/models/test_data_set.py
+++ b/stagecraft/apps/datasets/tests/models/test_data_set.py
@@ -12,15 +12,14 @@ from contextlib import contextmanager
 
 from nose.tools import assert_raises, assert_equal
 
-from django.core.exceptions import ValidationError, ObjectDoesNotExist
+from django.core.exceptions import ValidationError
 from django.db.models.deletion import ProtectedError
 from django.test import TestCase, TransactionTestCase
 
+from stagecraft.libs.backdrop_client import (
+    disable_backdrop_connection, BackdropNotFoundError)
 from stagecraft.apps.datasets.models import DataGroup, DataSet, DataType
 from stagecraft.apps.datasets.models.data_set import ImmutableFieldError
-
-from stagecraft.libs.backdrop_client import (
-    BackdropError, disable_backdrop_connection, BackdropNotFoundError)
 
 
 class DataSetTestCase(TestCase):
@@ -38,12 +37,7 @@ class DataSetTestCase(TestCase):
         cls.data_type1.delete()
         cls.data_type2.delete()
 
-    @disable_backdrop_connection
-    @mock.patch('stagecraft.apps.datasets.models.data_set.create_data_set')
-    @mock.patch('stagecraft.apps.datasets.models.data_set.delete_data_set')
-    def test_create_produces_a_name(self,
-                                    mock_delete_data_set,
-                                    mock_create_data_set):
+    def test_create_produces_a_name(self):
         with _make_temp_data_group_and_type() as (data_group, data_type):
             data_set1 = DataSet.objects.create(
                 data_group=data_group,
@@ -53,12 +47,7 @@ class DataSetTestCase(TestCase):
                 "{}_{}".format(data_group.name, data_type.name),
                 data_set1.name)
 
-    @disable_backdrop_connection
-    @mock.patch('stagecraft.apps.datasets.models.data_set.create_data_set')
-    @mock.patch('stagecraft.apps.datasets.models.data_set.delete_data_set')
-    def test_saving_existing_doesnt_change_the_name(self,
-                                                    mock_delete_data_set,
-                                                    mock_create_data_set):
+    def test_saving_existing_doesnt_change_the_name(self):
         with _make_temp_data_group_and_type() as (data_group, data_type):
             data_set1 = DataSet.objects.get(name='set1')
             data_set1.save()
@@ -66,11 +55,8 @@ class DataSetTestCase(TestCase):
             assert_equal('set1', data_set1.name)
 
     @disable_backdrop_connection
-    @mock.patch('stagecraft.apps.datasets.models.data_set.create_data_set')
     @mock.patch('stagecraft.apps.datasets.models.data_set.delete_data_set')
-    def test_create_and_delete(self,
-                               mock_delete_data_set,
-                               mock_create_data_set):
+    def test_create_and_delete(self, delete_data_set):
         with _make_temp_data_group_and_type() as (data_group, data_type):
 
             data_set1 = DataSet.objects.create(
@@ -83,7 +69,6 @@ class DataSetTestCase(TestCase):
 
             assert_equal(0, len(DataSet.objects.filter(name=data_set1.name)))
 
-    @disable_backdrop_connection
     def test_data_set_name_must_be_unique(self):
         a = DataSet.objects.create(
             data_group=self.data_group1,
@@ -96,7 +81,6 @@ class DataSetTestCase(TestCase):
             data_type=self.data_type1)
         assert_raises(ValidationError, lambda: b.validate_unique())
 
-    @disable_backdrop_connection
     def test_upload_filters_are_serialised_as_a_list(self):
         data_set1 = DataSet.objects.create(
             data_group=self.data_group1,
@@ -106,7 +90,6 @@ class DataSetTestCase(TestCase):
         assert_equal(data_set1.serialize()['upload_filters'],
                      ['aa.aa', 'bb.bb'])
 
-    @disable_backdrop_connection
     def test_auto_ids_are_serialised_as_a_list(self):
         data_set1 = DataSet.objects.create(
             data_group=self.data_group1,
@@ -115,7 +98,6 @@ class DataSetTestCase(TestCase):
 
         assert_equal(data_set1.serialize()['auto_ids'], ['aa', 'bb'])
 
-    @disable_backdrop_connection
     def test_data_group_data_type_combo_must_be_unique(self):
         data_set1 = DataSet.objects.create(
             data_group=self.data_group1,
@@ -128,7 +110,6 @@ class DataSetTestCase(TestCase):
             data_type=self.data_type1)
         assert_raises(ValidationError, lambda: data_set2.validate_unique())
 
-    @disable_backdrop_connection
     def test_name_cannot_be_changed(self):
         data_set = DataSet.objects.create(
             data_group=self.data_group1,
@@ -137,14 +118,12 @@ class DataSetTestCase(TestCase):
         data_set.name = 'Fred'
         assert_raises(ImmutableFieldError, data_set.save)
 
-    @disable_backdrop_connection
     def test_name_can_be_set_on_creation(self):
         DataSet.objects.create(
             name='Barney',
             data_group=self.data_group1,
             data_type=self.data_type1)
 
-    @disable_backdrop_connection
     def test_capped_size_cannot_be_changed(self):
         data_set = DataSet.objects.create(
             data_group=self.data_group1,
@@ -153,14 +132,12 @@ class DataSetTestCase(TestCase):
         data_set.capped_size = 42
         assert_raises(ImmutableFieldError, data_set.save)
 
-    @disable_backdrop_connection
     def test_capped_size_can_be_set_on_creation(self):
         DataSet.objects.create(
             data_group=self.data_group1,
             data_type=self.data_type1,
             capped_size=42)
 
-    @disable_backdrop_connection
     def test_cant_delete_referenced_data_group(self):
         refed_data_group = DataGroup.objects.create(name='refed_data_group')
         DataSet.objects.create(
@@ -169,7 +146,6 @@ class DataSetTestCase(TestCase):
 
         assert_raises(ProtectedError, lambda: refed_data_group.delete())
 
-    @disable_backdrop_connection
     def test_cant_delete_referenced_data_type(self):
         refed_data_type = DataType.objects.create(name='refed_data_type')
         DataSet.objects.create(
@@ -178,14 +154,12 @@ class DataSetTestCase(TestCase):
 
         assert_raises(ProtectedError, lambda: refed_data_type.delete())
 
-    @disable_backdrop_connection
     def test_bearer_token_defaults_to_blank(self):
         data_set = DataSet.objects.create(
             data_group=self.data_group1,
             data_type=self.data_type1)
         assert_equal('', data_set.bearer_token)
 
-    @disable_backdrop_connection
     def test_that_empty_bearer_token_serializes_to_null(self):
         data_set = DataSet.objects.create(
             data_group=self.data_group1,
@@ -193,38 +167,27 @@ class DataSetTestCase(TestCase):
             bearer_token='')
         assert_equal(None, data_set.serialize()['bearer_token'])
 
-    @mock.patch('stagecraft.apps.datasets.models.data_set.create_data_set')
-    def test_clean_raise_immutablefield_name_change(self,
-                                                    mock_create_data_set):
+    def test_clean_raise_immutablefield_name_change(self):
         data_set = DataSet.objects.create(
             data_group=self.data_group1,
             data_type=self.data_type1)
         data_set.name = "abc"
         assert_raises(ImmutableFieldError, lambda: data_set.clean())
 
-    @mock.patch('stagecraft.apps.datasets.models.data_set.create_data_set')
-    def test_clean_raise_immutablefield_cappedsize_change(
-            self,
-            mock_create_data_set):
+    def test_clean_raise_immutablefield_cappedsize_change(self):
         data_set = DataSet.objects.create(
             data_group=self.data_group1,
             data_type=self.data_type1)
         data_set.capped_size = 1000
         assert_raises(ImmutableFieldError, lambda: data_set.clean())
 
-    @mock.patch('stagecraft.apps.datasets.models.data_set.create_data_set')
-    def test_clean_not_raise_immutablefield_no_change(
-            self,
-            mock_create_data_set):
+    def test_clean_not_raise_immutablefield_no_change(self):
         data_set = DataSet.objects.create(
             data_group=self.data_group1,
             data_type=self.data_type1)
         data_set.clean()
 
-    @mock.patch('stagecraft.apps.datasets.models.data_set.create_data_set')
-    def test_clean_not_raise_immutablefield_normal_change(
-            self,
-            mock_create_data_set):
+    def test_clean_not_raise_immutablefield_normal_change(self):
         new_data_type = DataType.objects.create(name='new_data_type')
         data_set = DataSet.objects.create(
             data_group=self.data_group1,
@@ -276,72 +239,13 @@ def _assert_name_not_valid(name):
 class BackdropIntegrationTestCase(TransactionTestCase):
 
     """
-    Test that create_data_set() and delete_data_set() from
-    stagecraft.libs.backdrop_client are called appropriately on model
-    creation/deletion, and that Stagecraft responds appropriately.
+    Test that delete_data_set() from stagecraft.libs.backdrop_client is
+    called appropriately on model deletion, and that Stagecraft responds
+    appropriately.
     """
 
-    @mock.patch('stagecraft.apps.datasets.models.data_set.create_data_set')
-    def test_backdrop_is_called_on_model_create(self, mock_create_data_set):
-        with _make_temp_data_group_and_type() as (data_group, data_type):
-            dset = DataSet.objects.create(
-                data_group=data_group,
-                data_type=data_type)
-
-        mock_create_data_set.assert_called_once_with(dset.name, 0)
-
-    @mock.patch('stagecraft.apps.datasets.models.data_set.create_data_set')
-    def test_model_not_persisted_on_backdrop_error(self, mock_create_data_set):
-        # Not saved because of being rolled back
-        mock_create_data_set.side_effect = BackdropError('Failed')
-
-        with _make_temp_data_group_and_type() as (data_group, data_type):
-            assert_raises(
-                BackdropError,
-                lambda: DataSet.objects.create(
-                    data_group=data_group,
-                    data_type=data_type)
-            )
-
-            assert_raises(
-                ObjectDoesNotExist,
-                lambda: DataSet.objects.get(name="{}_{}".format(
-                    data_group, data_type
-                )))
-
-    @mock.patch('django.db.models.Model.save')
-    @mock.patch('stagecraft.apps.datasets.models.data_set.create_data_set')
-    def test_backdrop_not_called_if_theres_a_problem_saving_the_model(
-            self,
-            mock_create_data_set,
-            mock_save):
-
-        with _make_temp_data_group_and_type() as (data_group, data_type):
-            mock_save.side_effect = Exception("My first fake db error")
-            assert_raises(
-                Exception,
-                lambda: DataSet.objects.create(
-                    name='test_data_set_003',
-                    data_group=data_group,
-                    data_type=data_type)
-            )
-
-        assert_equal(mock_create_data_set.called, False)
-
-    @mock.patch('stagecraft.apps.datasets.models.data_set.create_data_set')
-    def test_backdrop_not_called_on_model_update(self, mock_create_data_set):
-        with _make_temp_data_group_and_type() as (data_group, data_type):
-            data_set = DataSet.objects.create(
-                data_group=data_group,
-                data_type=data_type)
-            data_set.save()
-            mock_create_data_set.assert_called_once_with(
-                data_set.name, 0)
-
-    @mock.patch('stagecraft.apps.datasets.models.data_set.create_data_set')
     @mock.patch('stagecraft.apps.datasets.models.data_set.delete_data_set')
-    def test_backdrop_is_called_on_model_delete(self, mock_delete_data_set,
-                                                mock_create_data_set):
+    def test_backdrop_is_called_on_model_delete(self, mock_delete_data_set):
         with _make_temp_data_group_and_type() as (data_group, data_type):
             data_set = DataSet.objects.create(
                 data_group=data_group,
@@ -350,10 +254,8 @@ class BackdropIntegrationTestCase(TransactionTestCase):
             data_set.delete()
         mock_delete_data_set.assert_called_once_with(data_set.name)
 
-    @mock.patch('stagecraft.apps.datasets.models.data_set.create_data_set')
     @mock.patch('stagecraft.apps.datasets.models.data_set.delete_data_set')
-    def test_data_set_deleted_when_backdrop_404s(self, mock_delete_data_set,
-                                                 mock_create_data_set):
+    def test_data_set_deleted_when_backdrop_404s(self, mock_delete_data_set):
         mock_delete_data_set.side_effect = BackdropNotFoundError
         with _make_temp_data_group_and_type() as (data_group, data_type):
             data_set = DataSet.objects.create(
@@ -367,10 +269,9 @@ class BackdropIntegrationTestCase(TransactionTestCase):
         mock_delete_data_set.assert_called_once_with(data_set.name)
         assert_equal(0, len(DataSet.objects.filter(name=data_set.name)))
 
-    @mock.patch('stagecraft.apps.datasets.models.data_set.create_data_set')
     @mock.patch('stagecraft.apps.datasets.models.data_set.delete_data_set')
-    def test_backdrop_is_called_on_query_set_delete(self, mock_delete_data_set,
-                                                    mock_create_data_set):
+    def test_backdrop_is_called_on_query_set_delete(self,
+                                                    mock_delete_data_set):
         with _make_temp_data_group_and_type() as (data_group, data_type):
             data_set = DataSet.objects.create(
                 name='test_data_set_006',

--- a/stagecraft/libs/backdrop_client/backdrop_client.py
+++ b/stagecraft/libs/backdrop_client/backdrop_client.py
@@ -97,31 +97,6 @@ def _get_headers():
 
 
 @check_disabled
-def create_data_set(name, capped_size):
-    """
-    Connect to Backdrop and create a new collection called ``name``.
-    Specify ``capped_size`` in bytes to create a capped collection, or 0 to
-    create an uncapped collection.
-    """
-
-    if not isinstance(capped_size, int) or capped_size < 0:
-        raise BackdropError(
-            "capped_size must be 0 or a positive integer number of bytes.")
-
-    json_request = json.dumps({'capped_size': capped_size})
-
-    endpoint_url = '{url}/data-sets/{name}'.format(url=settings.BACKDROP_URL,
-                                                   name=name)
-
-    backdrop_request = lambda: requests.post(
-        endpoint_url,
-        headers=_get_headers(),
-        data=json_request)
-
-    _send_backdrop_request(backdrop_request)
-
-
-@check_disabled
 def delete_data_set(name):
     """
     Connect to Backdrop and delete a collection called ``name``.

--- a/stagecraft/libs/mass_update/test_copy_dataset_with_new_mapping.py
+++ b/stagecraft/libs/mass_update/test_copy_dataset_with_new_mapping.py
@@ -1,6 +1,5 @@
 import mock
 from stagecraft.apps.datasets.models import DataSet
-from stagecraft.libs.backdrop_client import disable_backdrop_connection
 from django.test import TestCase
 from stagecraft.libs.mass_update import migrate_data_set
 from nose.tools import assert_equal
@@ -53,7 +52,7 @@ class TestDataSetMassUpdate(TestCase):
             }
         }
 
-        #existing data set config comes from fixture
+        # existing data set config comes from fixture
         self.new_dataset_config = {
             u'auto_ids': [u'foo', u'bar', u'baz'],
             u'bearer_token': None,
@@ -136,7 +135,6 @@ class TestDataSetMassUpdate(TestCase):
                 }
             ]}
 
-    @disable_backdrop_connection
     @mock.patch("performanceplatform.client.DataSet.get")
     @mock.patch("performanceplatform.client.DataSet.post")
     def test_correct_new_data_set_created(self, client_post, client_get):
@@ -151,7 +149,6 @@ class TestDataSetMassUpdate(TestCase):
         del new_data_set_serialised['schema']
         assert_equal(new_data_set_serialised, self.new_dataset_config)
 
-    @disable_backdrop_connection
     @mock.patch("performanceplatform.client.DataSet.get")
     @mock.patch("performanceplatform.client.DataSet.post")
     def test_handles_new_data_set_already_exists(
@@ -168,7 +165,6 @@ class TestDataSetMassUpdate(TestCase):
         assert_equal(new_data_set_serialised,
                      self.new_dataset_config_already_exists)
 
-    @disable_backdrop_connection
     @mock.patch("performanceplatform.client.DataSet.get")
     @mock.patch("performanceplatform.client.DataSet.post")
     def test_correct_data_posted_to_new_data_set_given_response(

--- a/stagecraft/libs/mass_update/test_data_set_mass_update.py
+++ b/stagecraft/libs/mass_update/test_data_set_mass_update.py
@@ -1,5 +1,4 @@
 from stagecraft.apps.datasets.models import DataGroup, DataSet, DataType
-from stagecraft.libs.backdrop_client import disable_backdrop_connection
 from django.test import TestCase
 from stagecraft.libs.mass_update import DataSetMassUpdate
 from nose.tools import assert_equal
@@ -7,7 +6,6 @@ from nose.tools import assert_equal
 
 class TestDataSetMassUpdate(TestCase):
     @classmethod
-    @disable_backdrop_connection
     def setUpClass(cls):
         cls.data_group1 = DataGroup.objects.create(name='datagroup1')
         cls.data_group2 = DataGroup.objects.create(name='datagroup2')
@@ -32,7 +30,6 @@ class TestDataSetMassUpdate(TestCase):
             bearer_token="999999",
             data_type=cls.data_type2)
 
-    @disable_backdrop_connection
     def test_update_bearer_token_by_date_type(self):
 
         new_bearer_token = "ghi789"
@@ -51,7 +48,6 @@ class TestDataSetMassUpdate(TestCase):
         assert_equal(dataset_b.bearer_token, new_bearer_token)
         assert_equal(dataset_c.bearer_token == new_bearer_token, False)
 
-    @disable_backdrop_connection
     def test_update_bearer_token_by_data_group(self):
 
         new_bearer_token = "ghi789"
@@ -70,7 +66,6 @@ class TestDataSetMassUpdate(TestCase):
         assert_equal(dataset_b.bearer_token, new_bearer_token)
         assert_equal(dataset_c.bearer_token, new_bearer_token)
 
-    @disable_backdrop_connection
     def test_update_bearer_token_by_data_group_and_data_type(self):
 
         new_bearer_token = "ghi789"


### PR DESCRIPTION
Backdrop will create data sets on it's side as they're written to now the dependency on backdrop can be removed from stagecraft for data set creation.

This avoids the cross app transaction bugs around creating data sets.

The dependency has not been removed for data set deletion. It is already a much more resilient process because if backdrop doesn't know a about a data set stagecraft just caries on.
