### PR TITLE
Update docs around making requests

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,8 +1,16 @@
-Example cURL reqest flow
+### Example cURL reqest flow
 
-```./run_development.sh```
+In **development** start the app
 
-then in another tab
+```
+./run_development.sh
+```
+
+then you should be able to do:
 
 ```curl -i -H "Authorization: Bearer development-oauth-access-token" http://0.0.0.0:3204/data-sets```
+
+In **production** curl requests should look something like this:
+
+```curl -i -H "Authorization: Bearer <SIGNON_API_USER_TOKEN>" https://stagecraft.performance.service.gov.uk/data-sets/<name_of_data_set>```
 

--- a/examples/backdrop-responses.json
+++ b/examples/backdrop-responses.json
@@ -22,10 +22,16 @@ GET /data-sets/<name>
 }
 
 
-Retrieve a user
-DOES NOT YET EXIST
+Retrieve a user for a specific data-set
 
-{
-  "email": "foo@bar.com",
-  "data_sets": ["foo", "bar"]
-}
+// GET /data-sets/<name_of_data_set>/users
+// curl -i -H "Authorization: Bearer <SIGNON_API_USER_TOKEN>" https://stagecraft.preview.performance.service.gov.uk/data-sets/carers_allowance_transactions_by_channel/users
+
+[
+  {
+    "email": "foo@bar.com",
+  },
+  {
+    "email": "another@email.com",
+  },
+]


### PR DESCRIPTION
- includes a live example that shows we need the signon api key, not the tokens that exist inside pp-deployment (are these now completely redundant?)
- Updates example json responses to show off the exciting new user listings
