### PR TITLE
This should be using django defaults not env

### DIFF
--- a/stagecraft/apps/datasets/views/common/utils.py
+++ b/stagecraft/apps/datasets/views/common/utils.py
@@ -4,7 +4,7 @@ from stagecraft.libs.validation.validation import extract_bearer_token
 from django.conf import settings
 from django.http import (HttpResponseForbidden)
 from django.utils.cache import patch_response_headers
-from statsd.defaults.env import statsd
+from statsd.defaults.django import statsd
 from functools import wraps
 
 


### PR DESCRIPTION
I accidently pulled in the defaults from environment variables rather
than the django settings but had set the vars in django settings. This
brings statsd into line and means we should now get the correct prefix.
