### PR TITLE
Bugfix: CSRF check rejecting reauth

### DIFF
--- a/stagecraft/apps/datasets/tests/views/test_auth.py
+++ b/stagecraft/apps/datasets/tests/views/test_auth.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.test import TestCase
+from django.test import TestCase, Client
 
 from hamcrest import assert_that, is_, is_not, equal_to
 from httmock import HTTMock
@@ -11,6 +11,7 @@ from ..support.test_helpers import is_unauthorized, is_forbidden
 
 class OAuthReauthTestCase(TestCase):
     def setUp(self):
+        self.client = Client(enforce_csrf_checks=True)
         settings.USE_DEVELOPMENT_USERS = False
 
     def tearDown(self):

--- a/stagecraft/apps/datasets/views/auth.py
+++ b/stagecraft/apps/datasets/views/auth.py
@@ -1,11 +1,13 @@
 from django.http import HttpResponse
 from django.views.decorators.cache import never_cache
+from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
 from ..models.oauth_user import OAuthUser
 from .common.utils import permission_required
 
 
+@csrf_exempt
 @require_POST
 @permission_required('user_update_permission')
 @never_cache


### PR DESCRIPTION
This makes the reauth view exempt from the CSRF check that Django adds
by default. This also updates the tests so that this is actually picked
up (Django switches the check off by default).

https://www.pivotaltracker.com/story/show/77119220
https://docs.djangoproject.com/en/dev/ref/contrib/csrf/#testing
