### PR TITLE
JSONSchema lib is now required always

### DIFF
--- a/requirements/_common.txt
+++ b/requirements/_common.txt
@@ -10,6 +10,8 @@ South==0.8.4
 requests==2.2.1
 logstash_formatter==0.5.7
 
+jsonschema==2.3.0
+
 # psycopg2 requires the libpq-dev package
 psycopg2==2.5.2
 

--- a/requirements/_testing.txt
+++ b/requirements/_testing.txt
@@ -11,6 +11,3 @@ coverage==3.6
 PyHamcrest==1.8.0
 
 httmock==1.2.2
-
-# Needed for validating schemas
-jsonschema==2.3.0


### PR DESCRIPTION
This library is now used to validate the options passed into a module.
