### PR TITLE
Reauth sends a PUT request not a POST

### DIFF
--- a/stagecraft/apps/datasets/tests/views/test_auth.py
+++ b/stagecraft/apps/datasets/tests/views/test_auth.py
@@ -32,7 +32,7 @@ class OAuthReauthTestCase(TestCase):
     def test_reauth_with_permission(self):
         self._create_oauth_user()
         with self._mock_signon(['signin', 'user_update_permission']):
-            resp = self.client.post(
+            resp = self.client.put(
                 '/auth/gds/api/users/the-uid/reauth',
                 HTTP_AUTHORIZATION='Bearer correct-token')
             assert_that(resp.status_code, equal_to(200))
@@ -43,7 +43,7 @@ class OAuthReauthTestCase(TestCase):
     def test_reauth_without_permission(self):
         self._create_oauth_user()
         with self._mock_signon(['signin']):
-            resp = self.client.post(
+            resp = self.client.put(
                 '/auth/gds/api/users/the-uid/reauth',
                 HTTP_AUTHORIZATION='Bearer correct-token')
             assert_that(resp, is_forbidden())
@@ -53,7 +53,7 @@ class OAuthReauthTestCase(TestCase):
 
     def test_reauth_returns_200_if_user_is_not_found(self):
         with self._mock_signon(['signin', 'user_update_permission']):
-            resp = self.client.post(
+            resp = self.client.put(
                 '/auth/gds/api/users/the-uid/reauth',
                 HTTP_AUTHORIZATION='Bearer correct-token')
             assert_that(resp.status_code, equal_to(200))
@@ -66,7 +66,7 @@ class OAuthReauthTestCase(TestCase):
         assert_that(resp.status_code, equal_to(200))
 
         with self._mock_signon(['signin', 'user_update_permission']):
-            self.client.post(
+            self.client.put(
                 '/auth/gds/api/users/the-uid/reauth',
                 HTTP_AUTHORIZATION='Bearer correct-token')
             resp = self.client.get(

--- a/stagecraft/apps/datasets/views/auth.py
+++ b/stagecraft/apps/datasets/views/auth.py
@@ -1,14 +1,14 @@
 from django.http import HttpResponse
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
-from django.views.decorators.http import require_POST
+from django.views.decorators.http import require_http_methods
 
 from ..models.oauth_user import OAuthUser
 from stagecraft.libs.authorization.http import permission_required
 
 
 @csrf_exempt
-@require_POST
+@require_http_methods(['PUT'])
 @permission_required('user_update_permission')
 @never_cache
 def reauth(user, request, uid):


### PR DESCRIPTION
We were only allowing POST through to the view handler but Sigonotron2
sends a PUT, whoops!
