### PR TITLE
We need to invalidate on update as well as reauth

### DIFF
--- a/stagecraft/apps/datasets/views/auth.py
+++ b/stagecraft/apps/datasets/views/auth.py
@@ -1,16 +1,16 @@
 from django.http import HttpResponse
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
-from django.views.decorators.http import require_POST
+from django.views.decorators.http import require_http_methods
 
 from ..models.oauth_user import OAuthUser
 from stagecraft.libs.authorization.http import permission_required
 
 
 @csrf_exempt
-@require_POST
+@require_http_methods(['POST', 'PUT'])
 @permission_required('user_update_permission')
 @never_cache
-def reauth(user, request, uid):
+def invalidate(user, request, uid):
     OAuthUser.objects.purge_user(uid)
     return HttpResponse('ok')

--- a/stagecraft/urls.py
+++ b/stagecraft/urls.py
@@ -19,7 +19,8 @@ urlpatterns = patterns(
     # http://bit.ly/1qkuGZ0
     url(r'^$', RedirectView.as_view(pattern_name='admin:index')),
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^auth/gds/api/users/(?P<uid>[\w-]+)/reauth', auth_views.reauth),
+    url(r'^auth/gds/api/users/(?P<uid>[\w-]+)/reauth$', auth_views.invalidate),
+    url(r'^auth/gds/api/users/(?P<uid>[\w-]+)$', auth_views.invalidate),
     # Note that the query string params get transparently passed to the view
     url(r'^data-sets$', datasets_views.list, name='data-sets-list'),
     url(r'^data-sets/$', RedirectView.as_view(pattern_name='data-sets-list',


### PR DESCRIPTION
Signon will send a reauth message when a user is logged out or
suspended, but a user can also lose permission to our app through their
permisssions being updated.

We should be invalidating on an update otherwise a user can be updated
to not have permissions and carry on using the app. BAD!
