### PR TITLE
Only cache a dasbhoard when published

### DIFF
--- a/stagecraft/apps/dashboards/tests/views/test_dashboard.py
+++ b/stagecraft/apps/dashboards/tests/views/test_dashboard.py
@@ -27,6 +27,18 @@ class DashboardViewsTestCase(TestCase):
         assert_that(json.loads(resp.content), equal_to(spotlightify_response))
         assert_that(resp['Cache-Control'], equal_to('max-age=300'))
 
+    def test_get_dashboards_only_caches_when_published(self):
+        DashboardFactory(slug='published_dashboard')
+        DashboardFactory(slug='unpublished_dashboard', published=False)
+
+        resp = self.client.get(
+            '/public/dashboards', {'slug': 'published_dashboard'})
+        assert_that(resp['Cache-Control'], equal_to('max-age=300'))
+
+        resp = self.client.get(
+            '/public/dashboards', {'slug': 'unpublished_dashboard'})
+        assert_that(resp['Cache-Control'], equal_to('no-cache'))
+
     @patch(
         'stagecraft.apps.dashboards.models.dashboard.Dashboard.spotlightify')
     def test_get_dashboards_with_slug_query_param_returns_404_if_no_dashboard(

--- a/stagecraft/apps/dashboards/views/dashboard.py
+++ b/stagecraft/apps/dashboards/views/dashboard.py
@@ -9,7 +9,6 @@ from django.views.decorators.cache import cache_control
 logger = logging.getLogger(__name__)
 
 
-@cache_control(max_age=300)
 def dashboards(request):
     dashboard_slug = request.GET.get('slug')
     dashboard = recursively_fetch_dashboard(dashboard_slug)
@@ -23,7 +22,14 @@ def dashboards(request):
         return HttpResponseNotFound(to_json(error))
     json_str = to_json(dashboard.spotlightify())
 
-    return HttpResponse(json_str, content_type='application/json')
+    response = HttpResponse(json_str, content_type='application/json')
+
+    if dashboard.published:
+        response['Cache-Control'] = 'max-age=300'
+    else:
+        response['Cache-Control'] = 'no-cache'
+
+    return response
 
 
 def recursively_fetch_dashboard(dashboard_slug, count=3):


### PR DESCRIPTION
We do the same for datasets as when working on a dashboard it is
frustrating to wait for the cache to invalidate when you make a change.
The assumption when a dashboard is unpublished should also be low load
to the url.
