### PR TITLE
Send django metrics to graphite

### DIFF
--- a/requirements/_common.txt
+++ b/requirements/_common.txt
@@ -20,3 +20,4 @@ performanceplatform-client==0.0.8
 
 # For writing stats out about our code
 statsd==3.0.1
+django-statsd-mozilla==0.3.12

--- a/stagecraft/apps/datasets/models/oauth_user.py
+++ b/stagecraft/apps/datasets/models/oauth_user.py
@@ -6,7 +6,7 @@ import logging
 from django.db import models, IntegrityError, InternalError
 from django.utils.encoding import python_2_unicode_compatible
 from south.utils.datetime_utils import datetime, timedelta
-from statsd.defaults.django import statsd
+from django_statsd.clients import statsd
 
 import dbarray
 

--- a/stagecraft/libs/authorization/http.py
+++ b/stagecraft/libs/authorization/http.py
@@ -5,7 +5,7 @@ from stagecraft.apps.datasets.models import OAuthUser
 from stagecraft.libs.validation.validation import extract_bearer_token
 from django.conf import settings
 from django.http import (HttpResponseForbidden, HttpResponse)
-from statsd.defaults.django import statsd
+from django_statsd.clients import statsd
 
 
 @statsd.timer('get_user.both')

--- a/stagecraft/settings/common.py
+++ b/stagecraft/settings/common.py
@@ -36,6 +36,7 @@ STATSD_HOST = 'localhost'
 STATSD_PORT = 8125
 STATSD_PREFIX = 'pp.apps.stagecraft'
 STATSD_MAXUDPSIZE = 512
+STATSD_CLIENT = 'django_statsd.clients.normal'
 
 
 def load_databases_from_environment():
@@ -72,6 +73,8 @@ INSTALLED_APPS = (
 )
 
 MIDDLEWARE_CLASSES = (
+    'django_statsd.middleware.GraphiteRequestTimingMiddleware',
+    'django_statsd.middleware.GraphiteMiddleware',
     'stagecraft.libs.request_logger.middleware.RequestLoggerMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -83,6 +86,9 @@ MIDDLEWARE_CLASSES = (
     'reversion.middleware.RevisionMiddleware',
 )
 
+STATSD_PATCHES = (
+    'django_statsd.patches.db',
+)
 ROOT_URLCONF = 'stagecraft.urls'
 
 WSGI_APPLICATION = 'stagecraft.wsgi.application'


### PR DESCRIPTION
Adds request times, request counts and database metrics to graphite.
