### PR TITLE
Remove redundant dataset permission

### DIFF
--- a/stagecraft/settings/development.py
+++ b/stagecraft/settings/development.py
@@ -33,7 +33,6 @@ DEVELOPMENT_USERS = {
         "organisation_slug": "cabinet-office",
         "permissions": [
             "signin",
-            "dataset",
             "user",
             "admin",
             "organisation",


### PR DESCRIPTION
It is not required by any view and is not required in either the new
admin app or the backdrop admin app.
