### PR TITLE
Remove django_statsd GraphiteMiddleware

### DIFF
--- a/stagecraft/settings/common.py
+++ b/stagecraft/settings/common.py
@@ -74,7 +74,6 @@ INSTALLED_APPS = (
 
 MIDDLEWARE_CLASSES = (
     'django_statsd.middleware.GraphiteRequestTimingMiddleware',
-    'django_statsd.middleware.GraphiteMiddleware',
     'stagecraft.libs.request_logger.middleware.RequestLoggerMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
This counts requests but doesn't use a .count suffix. We only aggregate
counting metrics correctly if they use a .count suffix. Rather than
changing our aggregation rules to be very django_statsd specific I have
removed this middleware. Besides, we get the same information from the
timers since they include a counter.
