### PR TITLE
Initial suggestion for FCO schemas

### DIFF
--- a/stagecraft/apps/datasets/schemas/data-types/appointments.json
+++ b/stagecraft/apps/datasets/schemas/data-types/appointments.json
@@ -1,0 +1,38 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "serviceType": {
+            "description": "The name of the service-type along which to segment the count",
+            "type": "string"
+        },
+        "count": {
+            "description": "The count of the number of events",
+            "type": "integer",
+            "minimum": 0
+        },
+        "consulate": {
+            "description": "The consular level for the number of events",
+            "type": "string"
+        },
+        "period": {
+            "description": "The period described by each data point",
+            "enum": [
+                "second",
+                "minute",
+                "hour",
+                "day",
+                "week",
+                "month",
+                "year"
+            ]
+        }
+    },
+    "required": [
+        "count",
+        "serviceType",
+        "consulate",
+        "period"
+    ],
+    "title": "Appointments by service type and consulate",
+    "type": "object"
+}

--- a/stagecraft/apps/datasets/schemas/data-types/no-show.json
+++ b/stagecraft/apps/datasets/schemas/data-types/no-show.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "count": {
+            "description": "The count of the number of events",
+            "type": "integer",
+            "minimum": 0
+        },
+        "consulate": {
+            "description": "The consular level for the number of events",
+            "type": "string"
+        },
+        "period": {
+            "description": "The period described by each data point",
+            "enum": [
+                "second",
+                "minute",
+                "hour",
+                "day",
+                "week",
+                "month",
+                "year"
+            ]
+        }
+    },
+    "required": [
+        "count",
+        "consulate",
+        "period"
+    ],
+    "title": "Number of no-shows for appointments",
+    "type": "object"
+}

--- a/stagecraft/apps/datasets/schemas/data-types/utilisation.json
+++ b/stagecraft/apps/datasets/schemas/data-types/utilisation.json
@@ -1,0 +1,34 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "percent": {
+            "description": "The percentage utilisation (between 0 and 100)",
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100
+        },
+        "consulate": {
+            "description": "The consular level for the number of events",
+            "type": "string"
+        },
+        "period": {
+            "description": "The period described by each data point",
+            "enum": [
+                "second",
+                "minute",
+                "hour",
+                "day",
+                "week",
+                "month",
+                "year"
+            ]
+        }
+    },
+    "required": [
+        "percent",
+        "consulate",
+        "period"
+    ],
+    "title": "Usage of available hours by consulate",
+    "type": "object"
+}


### PR DESCRIPTION
This is intended to support data capture and display for:
- number of appointments booked
- number of appointments booked, at consular level
- appointments by consular service type
- appointments by consular service type, at consular level
- appointments by channel, overall and at consular level
- number of no-shows for appointments, overall and at consular level
- usage of available hours, overall and by consulate
