### PR TITLE
Log Request-Id header from nginx proxy

### DIFF
--- a/stagecraft/libs/request_logger/middleware.py
+++ b/stagecraft/libs/request_logger/middleware.py
@@ -18,6 +18,7 @@ class RequestLoggerMiddleware(object):
                 'request_method': request.method,
                 'http_host': request.META.get('HTTP_HOST'),
                 'http_path': request.get_full_path(),
+                'request_id': request.META.get('HTTP_REQUEST_ID')
             })
 
     def process_response(self, request, response):


### PR DESCRIPTION
Our nginxen where SSL termination happens add a unique header for each
request. We should log that, to enable easier tracing in our
distributed system.
