### PR TITLE
[#75970986] Update dashboard via `PUT`

### DIFF
--- a/stagecraft/urls.py
+++ b/stagecraft/urls.py
@@ -54,4 +54,6 @@ urlpatterns = patterns(
     url(r'^module-type$', module_views.root_types),
     url(r'^dashboard/(?P<dashboard_id>{})/module$'.format(uuid_regexp),
         module_views.modules_on_dashboard),
+    url(r'^dashboard/(?P<dashboard_id>{})$'.format(uuid_regexp),
+        dashboard_views.dashboard, name='dashboard'),
 )


### PR DESCRIPTION
<sup>See: https://www.pivotaltracker.com/story/show/75970986</sup>
# Don't get sidetracked by verbs

The pattern has changed a bit now, but looks something like:
- To create a dashboard, `POST` to it without a resource id
- To edit it, send a `PUT` request, complete with a resource id

Innovations towards progress:
- `get_object_or_404` the dashboard you're attempting to update when you send a dashboard id
- `@require_http_methods(['POST', 'PUT'])` around the dashboard method to be a bit more explicit about what kind of things we expect in the `view` (_vis._ API controller)
- Adds a new route in `urls.py` for `dashboard/dashboard_id` so we can update pre-existing dashboards
