### PR TITLE
Always return a string in the 'message' field

### DIFF
--- a/stagecraft/apps/dashboards/tests/views/test_dashboard.py
+++ b/stagecraft/apps/dashboards/tests/views/test_dashboard.py
@@ -302,7 +302,7 @@ class DashboardViewsCreateTestCase(TestCase):
         data = {
             'slug': 'my-dashboard',
             'title': 'My dashboard',
-            'strapline': 'Invalid text',
+            'strapline': 'Invalid',
         }
 
         resp = self.client.post(
@@ -310,8 +310,9 @@ class DashboardViewsCreateTestCase(TestCase):
             content_type='application/json',
             HTTP_AUTHORIZATION='Bearer correct-token')
         response_dictionary = json.loads(resp.content)
+        expected_message = "strapline: Value u'Invalid' is not a valid choice."
 
         assert_that(resp.status_code, equal_to(400))
         assert_that(response_dictionary['status'], equal_to('error'))
-        assert_that(response_dictionary['message']['strapline'][0],
-                    equal_to("Value u'Invalid text' is not a valid choice."))
+        assert_that(response_dictionary['message'],
+                    equal_to(expected_message))

--- a/stagecraft/apps/dashboards/views/dashboard.py
+++ b/stagecraft/apps/dashboards/views/dashboard.py
@@ -98,9 +98,13 @@ def dashboard(user, request, dashboard_id=None):
     try:
         dashboard.full_clean()
     except ValidationError as error_details:
+        errors = error_details.message_dict
+        error_list = ['{0}: {1}'.format(field, ', '.join(errors[field]))
+                      for field in errors]
+        formatted_errors = ', '.join(error_list)
         error = {
             'status': 'error',
-            'message': error_details.message_dict,
+            'message': formatted_errors,
         }
         return HttpResponseBadRequest(to_json(error))
 


### PR DESCRIPTION
Other errors return a formatted string from the message field. A dashboard failing validation should follow this pattern so that API clients can simply output the string rather than processing it.

See alphagov/performanceplatform-admin#53 for more details.
