### PR TITLE
Update module api to take data group and data type

### DIFF
--- a/stagecraft/apps/dashboards/tests/views/test_module.py
+++ b/stagecraft/apps/dashboards/tests/views/test_module.py
@@ -175,13 +175,14 @@ class ModuleViewsTestCase(TestCase):
 
         assert_that(resp.status_code, is_(equal_to(404)))
 
-    def test_add_a_module_with_a_data_set(self):
+    def test_add_a_module_with_a_data_set_that_doesnt_exist(self):
         resp = self.client.post(
             '/dashboard/{}/module'.format(self.dashboard.id),
             data=json.dumps({
                 'slug': 'a-module',
                 'type_id': str(self.module_type.id),
-                'data_set_id': 'bad-id',
+                'data_group': 'bad-group',
+                'data_type': 'bad-type',
                 'title': 'Some module',
                 'description': 'Some text about the module',
                 'info': ['foo'],
@@ -200,7 +201,8 @@ class ModuleViewsTestCase(TestCase):
             data=json.dumps({
                 'slug': 'a-module',
                 'type_id': str(self.module_type.id),
-                'data_set_id': str(self.data_set.id),
+                'data_type': str(self.data_type.name),
+                'data_group': str(self.data_group.name),
                 'title': 'Some module',
                 'description': 'Some text about the module',
                 'info': ['foo'],
@@ -220,7 +222,8 @@ class ModuleViewsTestCase(TestCase):
             data=json.dumps({
                 'slug': 'a-module',
                 'type_id': str(self.module_type.id),
-                'data_set_id': str(self.data_set.id),
+                'data_type': str(self.data_type.name),
+                'data_group': str(self.data_group.name),
                 'title': 'Some module',
                 'description': 'Some text about the module',
                 'info': ['foo'],
@@ -283,7 +286,8 @@ class ModuleViewsTestCase(TestCase):
             data=json.dumps({
                 'slug': 'a-module',
                 'type_id': str(self.module_type.id),
-                'data_set_id': str(self.data_set.id),
+                'data_type': str(self.data_type.name),
+                'data_group': str(self.data_group.name),
                 'title': 'Some module',
                 'description': 'Some text about the module',
                 'info': ['foo'],

--- a/stagecraft/apps/dashboards/views/module.py
+++ b/stagecraft/apps/dashboards/views/module.py
@@ -73,9 +73,12 @@ def add_module_to_dashboard(dashboard, module_settings):
         raise ValueError(
             'options field failed validation: {}'.format(err.message))
 
-    if 'data_set_id' in module_settings:
+    if 'data_group' in module_settings and 'data_type' in module_settings:
         try:
-            data_set = DataSet.objects.get(id=module_settings['data_set_id'])
+            data_set = DataSet.objects.get(
+                data_group__name=module_settings['data_group'],
+                data_type__name=module_settings['data_type'],
+            )
         except DataSet.DoesNotExist:
             raise ValueError('data set does not exist')
 


### PR DESCRIPTION
Rather than a dataset_id which isnt exposed over the datasets api, and
is not currently a uuid. This also makes the api more consistent with
how we refer to datasets in other applications.
