### PR TITLE
Update transaction and other links in api response

### DIFF
--- a/stagecraft/apps/dashboards/models/dashboard.py
+++ b/stagecraft/apps/dashboards/models/dashboard.py
@@ -115,10 +115,10 @@ class Dashboard(models.Model):
         related_pages_dict = {}
         transaction_link = self.get_transaction_link()
         if transaction_link:
-            related_pages_dict['transaction_link'] = (
+            related_pages_dict['transaction'] = (
                 transaction_link.serialize())
 
-        related_pages_dict['other_links'] = [
+        related_pages_dict['other'] = [
             link.serialize() for link
             in self.get_other_links()
         ]

--- a/stagecraft/apps/dashboards/tests/models/test_dashboard.py
+++ b/stagecraft/apps/dashboards/tests/models/test_dashboard.py
@@ -103,12 +103,12 @@ class DashboardTestCase(TransactionTestCase):
                 'page-type': 'dashboard',
                 'relatedPages': has_entries({
                     'improve-dashboard-message': True,
-                    'transaction_link':
+                    'transaction':
                     has_entries({
                         'url': 'http://www.gov.uk',
                         'title': 'transaction',
                         }),
-                    'other_links':
+                    'other':
                     has_items(
                         has_entries({
                             'url': 'http://www.gov.uk',


### PR DESCRIPTION
Spotlight expects the fields to be named `other` and `transaction`
rather than `other_links` and `transaction_link`
