### PR TITLE
[#78806122] Return 400 on module validation error

### DIFF
--- a/stagecraft/apps/dashboards/models/module.py
+++ b/stagecraft/apps/dashboards/models/module.py
@@ -51,7 +51,7 @@ class Module(models.Model):
     id = UUIDField(auto=True, primary_key=True, hyphenate=True)
     type = models.ForeignKey(ModuleType)
     dashboard = models.ForeignKey(Dashboard)
-    data_set = models.ForeignKey(DataSet, null=True)
+    data_set = models.ForeignKey(DataSet, null=True, blank=True)
 
     slug_validator = RegexValidator(
         '^[-a-z0-9]+$',
@@ -66,10 +66,10 @@ class Module(models.Model):
 
     title = models.CharField(max_length=60)
     description = models.CharField(max_length=200)
-    info = TextArrayField()
+    info = TextArrayField(blank=True)
 
-    options = JSONField()
-    query_parameters = JSONField(null=True)
+    options = JSONField(blank=True)
+    query_parameters = JSONField(null=True, blank=True)
 
     order = models.IntegerField()
 

--- a/stagecraft/apps/dashboards/tests/views/test_dashboard.py
+++ b/stagecraft/apps/dashboards/tests/views/test_dashboard.py
@@ -257,7 +257,7 @@ class DashboardViewsCreateTestCase(TestCase):
                 'slug': slug,
                 'title': title,
                 'type_id': module_type.id,
-                'description': '',
+                'description': 'a description',
                 'info': [],
                 'options': {},
                 'order': order,
@@ -278,6 +278,28 @@ class DashboardViewsCreateTestCase(TestCase):
         assert_that(resp.status_code, equal_to(200))
         dashboard = Dashboard.objects.first()
         assert_that(dashboard.module_set.count(), equal_to(3))
+
+    @with_govuk_signon(permissions=['dashboard'])
+    def test_create_dashboard_fails_with_invalid_module(self):
+        module_type = ModuleTypeFactory()
+        module = {
+            'slug': 'bad slug',
+            'title': 'bad slug',
+            'type_id': module_type.id,
+            'description': '',
+            'info': [],
+            'options': {},
+            'order': 1,
+        }
+        data = self._get_dashboard_payload()
+        data['modules'] = [module]
+
+        resp = self.client.post(
+            '/dashboard', to_json(data),
+            content_type="application/json",
+            HTTP_AUTHORIZATION='Bearer correct-token')
+
+        assert_that(resp.status_code, equal_to(400))
 
     @with_govuk_signon(permissions=['dashboard'])
     def test_create_dashboard_with_reused_slug_is_bad_request(self):

--- a/stagecraft/apps/dashboards/tests/views/test_module.py
+++ b/stagecraft/apps/dashboards/tests/views/test_module.py
@@ -324,11 +324,30 @@ class ModuleViewsTestCase(TestCase):
                 'options': {
                     'thing': 'a value',
                 },
+                'order': 1,
             }),
             HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
             content_type='application/not-a-type')
 
         assert_that(resp.status_code, is_(equal_to(415)))
+
+    def test_add_a_module_fails_with_invalid_slug(self):
+        """Verifies that model validations are being run"""
+        resp = self.client.post(
+            '/dashboard/{}/module'.format(self.dashboard.id),
+            data=json.dumps({
+                'slug': 'bad slug',
+                'type_id': str(self.module_type.id),
+                'title': 'Some module',
+                'description': 'Some text about the module',
+                'info': ['foo'],
+                'options': {'thing': 'a value'},
+                'order': 1,
+            }),
+            HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
+            content_type='application/json')
+
+        assert_that(resp.status_code, equal_to(400))
 
 
 class ModuleTypeViewsTestCase(TestCase):

--- a/stagecraft/apps/dashboards/views/dashboard.py
+++ b/stagecraft/apps/dashboards/views/dashboard.py
@@ -7,7 +7,7 @@ from django.http import (HttpResponse,
                          HttpResponseBadRequest,
                          HttpResponseNotFound)
 from django.shortcuts import get_object_or_404
-from django.views.decorators.cache import cache_control, never_cache
+from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 
@@ -124,11 +124,19 @@ def dashboard(user, request, dashboard_id=None):
                                       **link_data)
 
     if 'modules' in data:
-        for module_data in data['modules']:
+        for i, module_data in enumerate(data['modules'], start=1):
             if 'id' in module_data:
                 raise NotImplemented("Not yet implemented updates")
             else:
-                add_module_to_dashboard(dashboard, module_data)
+                try:
+                    add_module_to_dashboard(dashboard, module_data)
+                except ValueError as e:
+                    error = {
+                        'status': 'error',
+                        'message': 'Failed to create module {}: {}'.format(
+                            i, e.message),
+                    }
+                    return HttpResponse(to_json(error), status=400)
 
     return HttpResponse(to_json(dashboard.serialize()),
                         content_type='application/json')


### PR DESCRIPTION
At the moment we fail with a 500 for what should be a 400.

This change required blank=True to be set on a few models. The 'null'
argument only applies to whether the database field can be null. The
'blank' argument applies to the validation.
