### PR TITLE
[#77608474] Implement dashboard `GET`

### DIFF
--- a/stagecraft/apps/dashboards/tests/views/test_dashboard.py
+++ b/stagecraft/apps/dashboards/tests/views/test_dashboard.py
@@ -3,7 +3,9 @@ import json
 
 from django.test import TestCase
 from hamcrest import (
-    assert_that, equal_to, is_, none, has_property, contains, has_entry, has_entries)
+    assert_that, equal_to, is_, none, has_property,
+    contains, has_entry, has_entries
+)
 from django_nose.tools import assert_redirects
 from mock import patch
 
@@ -78,7 +80,8 @@ class DashboardViewsListTestCase(TestCase):
         assert_that(returned_dashboard, is_(none()))
 
     @patch(
-        'stagecraft.apps.dashboards.models.dashboard.Dashboard.spotlightify')
+        'stagecraft.apps.dashboards.models.dashboard.Dashboard.spotlightify'
+    )
     def test_public_dashboards_with_forward_slash_redirects(
             self,
             spotlightify_patch):
@@ -122,7 +125,8 @@ class DashboardViewsGetTestCase(TestCase):
             '/dashboard/', HTTP_AUTHORIZATION='Bearer correct-token'
         )
         second_response = self.client.get(
-            '/dashboard/non-existant-m8', HTTP_AUTHORIZATION='Bearer correct-token'
+            '/dashboard/non-existant-m8',
+            HTTP_AUTHORIZATION='Bearer correct-token'
         )
 
         assert_that(resp.status_code, equal_to(404))

--- a/stagecraft/apps/dashboards/views/dashboard.py
+++ b/stagecraft/apps/dashboards/views/dashboard.py
@@ -55,16 +55,32 @@ def recursively_fetch_dashboard(dashboard_slug, count=3):
         if len(slug_parts) > 1:
             slug_parts.pop()
             dashboard = recursively_fetch_dashboard(
-                '/'.join(slug_parts), count=count-1)
+                '/'.join(slug_parts), count=count - 1)
 
     return dashboard
 
 
 @csrf_exempt
-@require_http_methods(['POST', 'PUT'])
+@require_http_methods(['GET'])
+@permission_required('dashboard')
+def get_dashboard(user, request, dashboard_id=None):
+    dashboard = get_object_or_404(Dashboard, id=dashboard_id)
+
+    return HttpResponse(
+        to_json(dashboard.serialize()),
+        content_type='application/json'
+    )
+
+
+@csrf_exempt
+@require_http_methods(['POST', 'PUT', 'GET'])
 @permission_required('dashboard')
 @never_cache
 def dashboard(user, request, dashboard_id=None):
+
+    if request.method == 'GET':
+        return get_dashboard(request, dashboard_id)
+
     data = json.loads(request.body)
 
     # create a dashboard if we don't already have a dashboard ID


### PR DESCRIPTION
## Nicer implementation pattern suggestions welcome
- The tests don't make assertions about UUIDs, as they constantly seem to change. **I THINK** this is by design, but would like to check before having this merged.
- We're still using the same url here, so the `dashboard` method routes to a `get_dashboard` method, which feels properly dumb but...
  - I didn't want to wrestle with trying to route based on the request inside `urls.py`
  - Annoyingly this means that `@require_http_methods` on the `dashboard` method now takes `(['POST', 'PUT', 'GET'])` which feels extra dumb, because we're putting routing logic in a bloody view, which feels like I'm leaving us with a curious beaƒt

![](http://ebba.english.ucsb.edu/images/cache/hunt_1_18306_2448x2448.jpg)
