### PR TITLE
Remove json.dumps() for options in dashboard tests

### DIFF
--- a/stagecraft/apps/dashboards/tests/views/test_dashboard.py
+++ b/stagecraft/apps/dashboards/tests/views/test_dashboard.py
@@ -142,7 +142,7 @@ class DashboardViewsListTestCase(TestCase):
             slug='module-we-want',
             info=['module-info'],
             title='module-title',
-            options=json.dumps({
+            options={
                 'tabs': [
                     {
                         'slug': 'tab-we-want',
@@ -152,7 +152,7 @@ class DashboardViewsListTestCase(TestCase):
                         'slug': 'tab-we-dont-want',
                     }
                 ]
-            }))
+            })
         ModuleFactory(
             type=module_type, dashboard=dashboard,
             slug='module-we-dont-want')
@@ -177,7 +177,7 @@ class DashboardViewsListTestCase(TestCase):
             slug='module',
             info=['module-info'],
             title='module-title',
-            options=json.dumps({
+            options={
                 'tabs': [
                     {
                         'slug': 'tab-we-want',
@@ -187,7 +187,7 @@ class DashboardViewsListTestCase(TestCase):
                         'slug': 'tab-we-dont-want',
                     }
                 ]
-            }))
+            })
         ModuleFactory(
             type=module_type, dashboard=dashboard,
             slug='module-we-dont-want')


### PR DESCRIPTION
These calls to json.dumps() around the options dictionary was causing the tests for fail locally for me. However, [the tests didn't fail when run on Travis](https://travis-ci.org/alphagov/stagecraft/builds/35526913).

I'm not sure this should be merged, I'm just opening it for more visibility than my comment on #231.
