### PR TITLE
Fix validation of modules with no data set

### DIFF
--- a/stagecraft/apps/dashboards/tests/views/test_module.py
+++ b/stagecraft/apps/dashboards/tests/views/test_module.py
@@ -1,4 +1,3 @@
-
 import json
 
 from django.test import TestCase
@@ -189,11 +188,33 @@ class ModuleViewsTestCase(TestCase):
                 'options': {
                     'thing': 'a value',
                 },
+                'order': 1,
             }),
             HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
             content_type='application/json')
 
         assert_that(resp.status_code, is_(equal_to(400)))
+
+    def test_add_a_module_with_an_empty_data_set(self):
+        resp = self.client.post(
+            '/dashboard/{}/module'.format(self.dashboard.id),
+            data=json.dumps({
+                'slug': 'a-module',
+                'type_id': str(self.module_type.id),
+                'data_group': '',
+                'data_type': '',
+                'title': 'Some module',
+                'description': 'a description',
+                'info': [],
+                'options': {
+                    'thing': 'a value',
+                },
+                'order': 1,
+            }),
+            HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
+            content_type='application/json')
+
+        assert_that(resp.status_code, is_(equal_to(200)))
 
     def test_add_a_module_with_a_data_set(self):
         resp = self.client.post(

--- a/stagecraft/apps/dashboards/views/module.py
+++ b/stagecraft/apps/dashboards/views/module.py
@@ -74,7 +74,7 @@ def add_module_to_dashboard(dashboard, module_settings):
         raise ValueError(
             'options field failed validation: {}'.format(err.message))
 
-    if 'data_group' in module_settings and 'data_type' in module_settings:
+    if module_settings.get('data_group') and module_settings.get('data_type'):
         try:
             data_set = DataSet.objects.get(
                 data_group__name=module_settings['data_group'],


### PR DESCRIPTION
Previously if the data_group and data_type were set but empty it would
fail with not being able to find the data set. As @timmow suggested, be
liberal in what you accept and conservative in what you emit.
