### PR TITLE
Do not cache module type or node list endpoints

### DIFF
--- a/stagecraft/apps/dashboards/views/module.py
+++ b/stagecraft/apps/dashboards/views/module.py
@@ -5,6 +5,7 @@ from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from jsonschema.exceptions import SchemaError, ValidationError
 from django.core.exceptions import ValidationError as DjangoValidationError
+from django.views.decorators.cache import never_cache
 
 from stagecraft.apps.datasets.models import DataSet
 from stagecraft.libs.authorization.http import permission_required
@@ -24,6 +25,7 @@ required_keys = set(['type_id', 'slug', 'title', 'description', 'info',
 
 
 @csrf_exempt
+@never_cache
 def modules_on_dashboard(request, dashboard_id):
     try:
         dashboard = Dashboard.objects.get(id=dashboard_id)
@@ -128,6 +130,7 @@ def add_module_to_dashboard_view(user, request, dashboard):
 
 
 @csrf_exempt
+@never_cache
 def root_types(request):
     if request.method == 'GET':
         return list_types(request)

--- a/stagecraft/apps/organisation/views.py
+++ b/stagecraft/apps/organisation/views.py
@@ -3,6 +3,7 @@ import json
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET
+from django.views.decorators.cache import never_cache
 
 from stagecraft.libs.authorization.http import permission_required
 from stagecraft.libs.validation.validation import is_uuid
@@ -17,6 +18,7 @@ def json_response(obj):
 
 
 @csrf_exempt
+@never_cache
 def root_nodes(request):
     if request.method == 'GET':
         return list_nodes(request)
@@ -116,6 +118,7 @@ def node_ancestors(request, node_id):
 
 
 @csrf_exempt
+@never_cache
 def root_types(request):
     if request.method == 'GET':
         return list_types(request)


### PR DESCRIPTION
The endpoints that are just going to be used by the admin app, we do not
want to cache.
