### PR TITLE
Use http in development as a default

### DIFF
--- a/do_dashboard_migration.py
+++ b/do_dashboard_migration.py
@@ -30,8 +30,7 @@ if __name__ == '__main__':
     for filename, json in spotlight_json(path):
         logger.debug('Creating dashboard for {}'.format(filename))
         # http in development
-        we_are_in_development_lol = getattr(settings, 'DEVELOPMENT', False)
-        if we_are_in_development_lol:
+        if settings.ENV_HOSTNAME == '.development.performance.service.gov.uk':
             base_url = 'http://stagecraft'
         else:
             base_url = 'https://stagecraft'

--- a/stagecraft/settings/development.py
+++ b/stagecraft/settings/development.py
@@ -17,7 +17,6 @@ import os
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = '^10-$qwyu##ivl7f48^mit5e8a-8q#6ceb5i5&zk86)$^(^rmn'
-DEVELOPMENT = True
 
 DEBUG = True
 TEMPLATE_DEBUG = True


### PR DESCRIPTION
- Provides a constant in development settings to set that we are in development
- Adds `DEVELOPMENT` to `settings.development`
- Allows us to switch in `do_dashboard_migration.py`
