### PR TITLE
Fix for list structure required by spotlight

### DIFF
--- a/stagecraft/apps/dashboards/models/dashboard.py
+++ b/stagecraft/apps/dashboards/models/dashboard.py
@@ -117,7 +117,7 @@ class Dashboard(models.Model):
 
         def spotlightify_for_list(item):
             return item.spotlightify_for_list()
-        return map(spotlightify_for_list, dashboards)
+        return {'items': map(spotlightify_for_list, dashboards)}
 
     def spotlightify_for_list(self):
         base_dict = self.list_base_dict()

--- a/stagecraft/apps/dashboards/tests/models/test_dashboard.py
+++ b/stagecraft/apps/dashboards/tests/models/test_dashboard.py
@@ -28,8 +28,8 @@ class DashboardTestCase(TransactionTestCase):
         dashboard_two.validate_and_save()
         unpublished_dashboard = DashboardFactory(published=False)
         list_for_spotlight = Dashboard.list_for_spotlight()
-        assert_that(len(list_for_spotlight), equal_to(2))
-        assert_that(list_for_spotlight[1],
+        assert_that(len(list_for_spotlight['items']), equal_to(2))
+        assert_that(list_for_spotlight['items'][1],
                     has_entries({
                         'slug': starts_with('slug'),
                         'title': 'title',
@@ -43,7 +43,7 @@ class DashboardTestCase(TransactionTestCase):
                             'abbr': starts_with('abbreviation')
                         })
                     }))
-        assert_that(list_for_spotlight[0],
+        assert_that(list_for_spotlight['items'][0],
                     has_entries({
                         'slug': starts_with('slug'),
                         'title': 'title',


### PR DESCRIPTION
In order to match what spotlight expects we must wrap the returned list
in 'items'. It is debateable whether spotlight should change rather than
this but considering this end point is only to be used in spotlight it
seems it's better it should happen here.
