### PR TITLE
Allow empty query_parameters on add module

### DIFF
--- a/stagecraft/apps/dashboards/tests/views/test_module.py
+++ b/stagecraft/apps/dashboards/tests/views/test_module.py
@@ -216,6 +216,28 @@ class ModuleViewsTestCase(TestCase):
 
         assert_that(resp.status_code, is_(equal_to(200)))
 
+    def test_add_a_module_with_an_empty_data_set_and_query_parameters(self):
+        resp = self.client.post(
+            '/dashboard/{}/module'.format(self.dashboard.id),
+            data=json.dumps({
+                'slug': 'a-module',
+                'type_id': str(self.module_type.id),
+                'data_group': '',
+                'data_type': '',
+                'title': 'Some module',
+                'description': 'a description',
+                'info': [],
+                'options': {
+                    'thing': 'a value',
+                },
+                'order': 1,
+                'query_parameters': {},
+            }),
+            HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
+            content_type='application/json')
+
+        assert_that(resp.status_code, is_(equal_to(200)))
+
     def test_add_a_module_with_a_data_set(self):
         resp = self.client.post(
             '/dashboard/{}/module'.format(self.dashboard.id),

--- a/stagecraft/apps/dashboards/views/module.py
+++ b/stagecraft/apps/dashboards/views/module.py
@@ -93,7 +93,7 @@ def add_module_to_dashboard(dashboard, module_settings):
         except ValidationError as err:
             raise ValueError(
                 'Query parameters not valid: {}'.format(err.message))
-    elif 'query_parameters' in module_settings:
+    elif module_settings.get('query_parameters'):
         raise ValueError('query_parameters but no data set')
 
     try:


### PR DESCRIPTION
When adding a module to a dashboard, if there is no data set then allow
query_parameters to be present but empty rather than just not present.

The admin app will always provide query_parameters regardless of whether
there is a data set. It will provide an empty dictionary by default.
