### PR TITLE
Add GET /dashboards to return a list of dashboards

### DIFF
--- a/stagecraft/apps/dashboards/tests/views/test_dashboard.py
+++ b/stagecraft/apps/dashboards/tests/views/test_dashboard.py
@@ -4,7 +4,7 @@ import json
 from django.test import TestCase
 from hamcrest import (
     assert_that, equal_to, is_, none, has_property,
-    contains, has_entry, has_entries
+    contains, has_entry, has_entries, has_key, starts_with
 )
 from django_nose.tools import assert_redirects
 from mock import patch
@@ -22,6 +22,27 @@ from stagecraft.libs.views.utils import JsonEncoder
 
 
 class DashboardViewsListTestCase(TestCase):
+
+    def test_list_dashboards_lists_dashboards(self):
+        DashboardFactory(slug='dashboard', title='Dashboard', published=True)
+        resp = self.client.get(
+            '/dashboards',
+            HTTP_AUTHORIZATION='Bearer development-oauth-access-token')
+        response_object = json.loads(resp.content)['dashboards']
+
+        public_url = ('http://spotlight.development.performance.service'
+                      '.gov.uk/performance/dashboard')
+        internal_url = ('http://stagecraft.development.performance.service'
+                        '.gov.uk/dashboard/')
+        base_expectation = {
+            'title': 'Dashboard',
+            'public-url': public_url,
+            'published': True,
+        }
+
+        assert_that(response_object[0], has_entries(base_expectation))
+        assert_that(response_object[0], has_key('id'))
+        assert_that(response_object[0]['url'], starts_with(internal_url))
 
     @patch(
         "stagecraft.apps.dashboards.models."

--- a/stagecraft/settings/development.py
+++ b/stagecraft/settings/development.py
@@ -24,6 +24,9 @@ TEMPLATE_DEBUG = True
 APP_HOSTNAME = 'stagecraft.development.performance.service.gov.uk'
 ENV_HOSTNAME = '.development.performance.service.gov.uk'
 
+APP_ROOT = 'http://{0}'.format(APP_HOSTNAME)
+GOVUK_ROOT = 'http://spotlight.development.performance.service.gov.uk'
+
 SIGNON_URL = 'http://signon.dev.gov.uk'
 USE_DEVELOPMENT_USERS = True
 DEVELOPMENT_USERS = {

--- a/stagecraft/urls.py
+++ b/stagecraft/urls.py
@@ -45,6 +45,9 @@ urlpatterns = patterns(
     url(r'^organisation/type$', organisation_views.root_types),
     url(r'^_status/data-sets$', datasets_views.health_check),
     url(r'^_status$', status_views.status),
+
+    # Dashboards
+    url(r'^dashboards$', dashboard_views.list_dashboards),
     url(r'^dashboard$', dashboard_views.dashboard, name='dashboard'),
     url(
         r'^public/dashboards$',


### PR DESCRIPTION
This endpoint returns a list of all dashboards in the database, formatted with:
- `id`, the UUID of the dashboard
- `title`
- `url`, the Stagecraft endpoint for the dashboard
- `public-url`, the dashboard's location on GOV.UK
- `published`, a boolean indicating publishedness
