### PR TITLE
Add type to link response to mirror what is being posted.

### DIFF
--- a/stagecraft/apps/dashboards/models/dashboard.py
+++ b/stagecraft/apps/dashboards/models/dashboard.py
@@ -256,7 +256,8 @@ class Link(models.Model):
     def serialize(self):
         return {
             'title': self.title,
-            'url': self.url,
+            'type': self.link_type,
+            'url': self.url
         }
 
     class Meta:

--- a/stagecraft/apps/dashboards/tests/models/test_dashboard.py
+++ b/stagecraft/apps/dashboards/tests/models/test_dashboard.py
@@ -195,6 +195,7 @@ class DashboardTestCase(TransactionTestCase):
 
         expected_link = {
             'url': u'https://www.gov.uk/link-1',
+            'type': u'transaction',
             'title': u'Link title'
         }
 


### PR DESCRIPTION
This should allow us to render and edit form

I feel like I am missing something. I shall ask Tim if this is genuinely all there is to it.

We may also be missing other fields in the get which we'll discover as we go through edit.
