### PR TITLE
Allow PUTs containing modules to work correctly

### DIFF
--- a/requirements/_common.txt
+++ b/requirements/_common.txt
@@ -16,7 +16,7 @@ jsonschema==2.3.0
 psycopg2==2.5.2
 
 # For performing data operations that require speaking to backdrop
-performanceplatform-client==0.0.8
+performanceplatform-client==0.2.4
 
 # For writing stats out about our code
 statsd==3.0.1

--- a/stagecraft/apps/dashboards/tests/factories/factories.py
+++ b/stagecraft/apps/dashboards/tests/factories/factories.py
@@ -1,6 +1,7 @@
 import factory
 from ...models import Dashboard, Link, ModuleType, Module
 from ....organisation.models import Node, NodeType
+from ....datasets.models import DataSet, DataType, DataGroup
 
 
 class DashboardFactory(factory.DjangoModelFactory):
@@ -76,3 +77,23 @@ class AgencyFactory(NodeFactory):
 
 class AgencyWithDepartmentFactory(AgencyFactory):
     parent = factory.SubFactory(DepartmentFactory)
+
+
+class DataGroupFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = DataGroup
+    name = factory.Sequence(lambda n: 'data-group-%s' % n)
+
+
+class DataTypeFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = DataType
+    name = factory.Sequence(lambda n: 'data-type-%s' % n)
+
+
+class DataSetFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = DataSet
+
+    data_type = factory.SubFactory(DataTypeFactory)
+    data_group = factory.SubFactory(DataGroupFactory)

--- a/stagecraft/apps/dashboards/views/dashboard.py
+++ b/stagecraft/apps/dashboards/views/dashboard.py
@@ -20,6 +20,7 @@ from stagecraft.libs.validation.validation import is_uuid
 from stagecraft.libs.views.utils import to_json
 from stagecraft.libs.views.transaction import atomic_view
 from .module import add_module_to_dashboard
+from ..models.module import Module
 
 logger = logging.getLogger(__name__)
 
@@ -220,20 +221,17 @@ def dashboard(user, request, dashboard_id=None):
 
     if 'modules' in data:
         for i, module_data in enumerate(data['modules'], start=1):
-            if 'id' in module_data:
-                raise NotImplemented("Not yet implemented updates")
-            else:
-                try:
-                    add_module_to_dashboard(dashboard, module_data)
-                except ValueError as e:
-                    error = {
-                        'status': 'error',
-                        'message': 'Failed to create module {}: {}'.format(
-                            i, e.message),
-                        'errors': [create_error(request, 400,
-                                                detail=e.message)]
-                    }
-                    return HttpResponse(to_json(error), status=400)
+            try:
+                add_module_to_dashboard(dashboard, module_data)
+            except ValueError as e:
+                error = {
+                    'status': 'error',
+                    'message': 'Failed to create module {}: {}'.format(
+                        i, e.message),
+                    'errors': [create_error(request, 400,
+                                            detail=e.message)]
+                }
+                return HttpResponse(to_json(error), status=400)
 
     return HttpResponse(to_json(dashboard.serialize()),
                         content_type='application/json')

--- a/stagecraft/apps/dashboards/views/module.py
+++ b/stagecraft/apps/dashboards/views/module.py
@@ -58,17 +58,24 @@ def add_module_to_dashboard(dashboard, module_settings):
     except ModuleType.DoesNotExist:
         raise ValueError('module type was not found')
 
-    module = Module(
-        dashboard=dashboard,
-        type=module_type,
+    if 'id' in module_settings:
+        try:
+            module = Module.objects.get(id=module_settings['id'])
+        except Module.DoesNotExist as e:
+            raise ValueError('module with id {} not found'.format(
+                module_data['id']))
+    else:
+        module = Module(
+        )
 
-        slug=module_settings['slug'],
-        title=module_settings['title'],
-        description=module_settings['description'],
-        info=module_settings['info'],
-        options=module_settings['options'],
-        order=module_settings['order'],
-    )
+    module.dashboard = dashboard
+    module.type = module_type
+    module.slug = module_settings['slug']
+    module.title = module_settings['title']
+    module.description = module_settings['description']
+    module.info = module_settings['info']
+    module.options = module_settings['options']
+    module.order = module_settings['order']
 
     try:
         module.validate_options()

--- a/stagecraft/settings/development.py
+++ b/stagecraft/settings/development.py
@@ -147,6 +147,11 @@ LOGGING = {
         },
     },
     'loggers': {
+        '': {
+            'handlers': ['logfile', 'json_log'],
+            'level': 'INFO',
+            'propagate': True,  # also handle in parent handler
+        },
         'django.request': {
             'handlers': ['console', 'logfile', 'json_log'],
             'level': 'INFO',


### PR DESCRIPTION
When putting a list of modules, if they include an id, then update the
module with data from the PUT request.

Not yet implemented removing module as it is a separate story, but have
added a skipped test for this functionality
