### PR TITLE
Switch to data_group and data_type in get response

### DIFF
--- a/stagecraft/apps/dashboards/models/module.py
+++ b/stagecraft/apps/dashboards/models/module.py
@@ -118,9 +118,8 @@ class Module(models.Model):
         }
 
         if self.data_set is not None:
-            out['data_set'] = {
-                'id': self.data_set.id,
-            }
+            out['data_group'] = self.data_set.data_group.name
+            out['data_type'] = self.data_set.data_type.name
         else:
             out['data_set'] = None
 

--- a/stagecraft/apps/dashboards/tests/models/test_module.py
+++ b/stagecraft/apps/dashboards/tests/models/test_module.py
@@ -174,8 +174,13 @@ class ModuleTestCase(TestCase):
             serialization['query_parameters'],
             has_entry('foo', 'bar'))
         assert_that(
-            serialization['data_set']['id'],
-            equal_to(self.data_set.id))
+            serialization, has_entry(
+                'data_group',
+                equal_to(self.data_set.data_group.name)))
+        assert_that(
+            serialization, has_entry(
+                'data_type',
+                equal_to(self.data_set.data_type.name)))
 
         module.delete()
 
@@ -199,8 +204,14 @@ class ModuleTestCase(TestCase):
 
         assert_that(serialization['query_parameters'], equal_to(None))
         assert_that(
-            serialization['data_set']['id'],
-            equal_to(self.data_set.id))
+            serialization,
+            has_entry(
+                'data_group', equal_to(self.data_set.data_group.name)))
+
+        assert_that(
+            serialization,
+            has_entry(
+                'data_type', equal_to(self.data_set.data_type.name)))
 
         module.delete()
 


### PR DESCRIPTION
Avoid exposing the data_set id in the api, as it is a numeric field rather
than a uuid, and we use data_group and data_type for creating modules, and
never require the id.
