### PR TITLE
Add page-type to list of dashboards

### DIFF
--- a/stagecraft/apps/dashboards/models/dashboard.py
+++ b/stagecraft/apps/dashboards/models/dashboard.py
@@ -117,7 +117,10 @@ class Dashboard(models.Model):
 
         def spotlightify_for_list(item):
             return item.spotlightify_for_list()
-        return {'items': map(spotlightify_for_list, dashboards)}
+        return {
+            'page-type': 'browse',
+            'items': map(spotlightify_for_list, dashboards),
+        }
 
     def spotlightify_for_list(self):
         base_dict = self.list_base_dict()

--- a/stagecraft/apps/dashboards/tests/models/test_dashboard.py
+++ b/stagecraft/apps/dashboards/tests/models/test_dashboard.py
@@ -28,6 +28,7 @@ class DashboardTestCase(TransactionTestCase):
         dashboard_two.validate_and_save()
         unpublished_dashboard = DashboardFactory(published=False)
         list_for_spotlight = Dashboard.list_for_spotlight()
+        assert_that(list_for_spotlight['page-type'], equal_to('browse'))
         assert_that(len(list_for_spotlight['items']), equal_to(2))
         assert_that(list_for_spotlight['items'][1],
                     has_entries({


### PR DESCRIPTION
Spotlight needs this, and we should ensure it’s part of the published
schema.
