### PR TITLE
Allow posting empty module id

### DIFF
--- a/stagecraft/apps/dashboards/tests/views/test_module.py
+++ b/stagecraft/apps/dashboards/tests/views/test_module.py
@@ -3,12 +3,13 @@ import json
 from django.test import TestCase
 from hamcrest import (
     assert_that, equal_to, is_,
-    has_entry, has_item, has_key, is_not
+    has_entry, has_item, has_key, is_not, has_length
 )
 
 from stagecraft.apps.datasets.models import DataGroup, DataType, DataSet
 from stagecraft.libs.backdrop_client import disable_backdrop_connection
 from ...models import Dashboard, Module, ModuleType
+from ...views.module import add_module_to_dashboard
 
 
 class ModuleViewsTestCase(TestCase):
@@ -392,6 +393,24 @@ class ModuleViewsTestCase(TestCase):
             content_type='application/json')
 
         assert_that(resp.status_code, equal_to(400))
+
+    def test_add_a_module_wih_an_empty_id(self):
+        """Verifies that model validations are being run"""
+        add_module_to_dashboard(
+            self.dashboard,
+            {
+                'id': '',
+                'slug': 'a-module',
+                'type_id': str(self.module_type.id),
+                'title': 'Some module',
+                'description': 'Some text about the module',
+                'info': ['foo'],
+                'options': {'thing': 'a value'},
+                'order': 1,
+            }
+        )
+        dashboard = Dashboard.objects.get(id=self.dashboard.id)
+        assert_that(dashboard.module_set.all(), has_length(1))
 
 
 class ModuleTypeViewsTestCase(TestCase):

--- a/stagecraft/apps/dashboards/views/module.py
+++ b/stagecraft/apps/dashboards/views/module.py
@@ -58,7 +58,7 @@ def add_module_to_dashboard(dashboard, module_settings):
     except ModuleType.DoesNotExist:
         raise ValueError('module type was not found')
 
-    if 'id' in module_settings:
+    if module_settings.get('id'):
         try:
             module = Module.objects.get(id=module_settings['id'])
         except Module.DoesNotExist as e:


### PR DESCRIPTION
This is to avoid doing a lookup on an empty key, which results in a
server error, and is to follow the "be liberal in what you accept"
principle.
