### PR TITLE
Delete modules not provided on PUT

### DIFF
--- a/stagecraft/apps/dashboards/tests/views/test_dashboard.py
+++ b/stagecraft/apps/dashboards/tests/views/test_dashboard.py
@@ -425,7 +425,6 @@ class DashboardViewsUpdateTestCase(TestCase):
 
         assert_that(resp.status_code, equal_to(400))
 
-    @nottest
     @with_govuk_signon(permissions=['dashboard'])
     def test_removing_module(self):
         dashboard = DashboardFactory(title='test dashboard')
@@ -444,7 +443,7 @@ class DashboardViewsUpdateTestCase(TestCase):
         assert_that(resp.status_code, equal_to(200))
         assert_that(json.loads(
             resp.content), has_entry('modules', has_length(0)))
-        assert_that(Module.objects.get(id=module.id), has_length(0))
+        assert_that(Module.objects.filter(id=module.id), has_length(0))
 
     @with_govuk_signon(permissions=['dashboard'])
     def test_update_existing_link(self):

--- a/stagecraft/apps/dashboards/views/dashboard.py
+++ b/stagecraft/apps/dashboards/views/dashboard.py
@@ -247,9 +247,12 @@ def dashboard(user, request, identifier=None):
                                           **link_data)
 
     if 'modules' in data:
+        module_ids = set([m.id for m in dashboard.module_set.all()])
+
         for i, module_data in enumerate(data['modules'], start=1):
             try:
-                add_module_to_dashboard(dashboard, module_data)
+                module = add_module_to_dashboard(dashboard, module_data)
+                module_ids.discard(module.id)
             except ValueError as e:
                 error = {
                     'status': 'error',
@@ -259,6 +262,8 @@ def dashboard(user, request, identifier=None):
                                             detail=e.message)]
                 }
                 return HttpResponse(to_json(error), status=400)
+
+        Module.objects.filter(id__in=module_ids).delete()
 
     return HttpResponse(to_json(dashboard.serialize()),
                         content_type='application/json')


### PR DESCRIPTION
When a dashboard is updated and the 'modules' key is present but there
are modules linked to the dashboard that are not provided. Delete them!

This fits with the idea that PUTing a dashboard is pushing the resource
and is idempotent(ish).
