### PR TITLE
Sort list of dashboards by title

### DIFF
--- a/stagecraft/apps/dashboards/tests/views/test_dashboard.py
+++ b/stagecraft/apps/dashboards/tests/views/test_dashboard.py
@@ -48,6 +48,17 @@ class DashboardViewsListTestCase(TestCase):
         assert_that(response_object[0], has_key('id'))
         assert_that(response_object[0]['url'], starts_with(internal_url))
 
+    def test_list_dashboards_list_alphabetically(self):
+        DashboardFactory(slug='dashboard-1', title='Alpha')
+        DashboardFactory(slug='dashboard-2', title='Beta')
+        resp = self.client.get(
+            '/dashboards',
+            HTTP_AUTHORIZATION='Bearer development-oauth-access-token')
+        response_object = json.loads(resp.content)['dashboards']
+
+        assert_that(response_object[0]['title'], is_('Alpha'))
+        assert_that(response_object[1]['title'], is_('Beta'))
+
     @patch(
         "stagecraft.apps.dashboards.models."
         "dashboard.Dashboard.list_for_spotlight")

--- a/stagecraft/apps/dashboards/views/dashboard.py
+++ b/stagecraft/apps/dashboards/views/dashboard.py
@@ -94,7 +94,7 @@ def recursively_fetch_dashboard(dashboard_slug, count=3):
 def list_dashboards(user, request):
     parsed_dashboards = []
 
-    for item in Dashboard.objects.all():
+    for item in Dashboard.objects.all().order_by('title'):
         parsed_dashboards.append({
             'id': item.id,
             'title': item.title,


### PR DESCRIPTION
Based on feedback, it would be better to have the list of dashboards sorted by something. Right now I've decided to sort dashboards by title, but if anyone has a need to change this sort they should feel free to.
