### PR TITLE
import schemas

### DIFF
--- a/import_schemas.py
+++ b/import_schemas.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+from stagecraft.apps.dashboards.models.module import(
+    ModuleType,
+    Module)
+import os
+import json
+import pprint
+import jsonschema
+
+# For this script to work correctly, you need to run
+# run it like this:
+# workon/source the virtualenv
+# run export DJANGO_SETTINGS_MODULE=stagecraft.settings.production
+# venv/bin/python import.py
+
+
+def get_schema_for_module_type(name):
+    path = os.path.join(
+        os.path.dirname(__file__),
+        'tools/import_schemas/schema/modules_json/{}_schema.json'.format(name))
+    try:
+        with open(path, "r") as file:
+            schema = file.read()
+    except IOError as e:
+        print "NO SCHEMA FOUND - USING DEFAULT"
+        print name
+        print "^NO SCHEMA FOUND - USING DEFAULT"
+        path = os.path.join(
+            os.path.dirname(__file__),
+            'tools/import_schemas/schema/module_schema.json'.format(name))
+        with open(path, "r") as file:
+            schema = file.read()
+    schema_dict = json.loads(schema)
+    return schema_dict
+
+
+def check_module_type_schemas_correct():
+    for module_type, new_schema in module_types_with_proper_schemas():
+        try:
+            module_type.validate_schema()
+        except jsonschema.exceptions.SchemaError as e:
+            print "==============="
+            print module_type.name
+            print "==============="
+            raise e
+
+
+def clear_module_type_schemas():
+    for module_type, new_schema in module_types_with_proper_schemas():
+        update_module_type_schema(module_type, schema={})
+
+
+def update_module_type_with_correct_schemas():
+    for module_type, new_schema in module_types_with_proper_schemas():
+        update_module_type_schema(module_type, schema=new_schema)
+
+
+def update_module_type_schema(module_type, schema={}):
+    module_type.schema = schema
+    module_type.save()
+
+
+def module_types_with_proper_schemas():
+    module_types_with_proper_schemas = [
+        (module_type, get_schema_for_module_type(module_type.name))
+        for module_type in ModuleType.objects.all()
+    ]
+    return module_types_with_proper_schemas
+
+
+def validate_all_modules():
+    for module in Module.objects.all():
+        module.validate_options()
+        print "======"
+        print "{} valid in {} dashboard".format(
+            module.slug, module.dashboard.slug)
+        print "^====="
+    return True
+
+
+def validate_all_modules_against_files():
+    for module in Module.objects.all():
+        schema = get_schema_for_module_type(module.type.name)
+        jsonschema.validate(module.options, schema)
+        print "======"
+        print "{} valid in {} dashboard".format(
+            module.slug, module.dashboard.slug)
+        print "^====="
+    return True
+
+
+if __name__ == '__main__':
+    print "Clearing schemas"
+    clear_module_type_schemas()
+    print "Checking schemas valid"
+    check_module_type_schemas_correct()
+    print "Checking current modules valid"
+    validate_all_modules_against_files()
+    print "Setting module type schemas"
+    update_module_type_with_correct_schemas()
+    print "Checking current modules valid using real method"
+    validate_all_modules()

--- a/stagecraft/apps/dashboards/models/module.py
+++ b/stagecraft/apps/dashboards/models/module.py
@@ -1,5 +1,6 @@
 import copy
 import jsonschema
+from jsonschema import Draft3Validator
 
 from django.core.validators import RegexValidator
 from django.db import models
@@ -35,8 +36,9 @@ class ModuleType(models.Model):
     class Meta:
         app_label = 'dashboards'
 
+    #should run on normal validate
     def validate_schema(self):
-        validator_for(self.schema).check_schema(self.schema)
+        validator_for(self.schema, Draft3Validator).check_schema(self.schema)
         return True
 
     def serialize(self):
@@ -73,10 +75,12 @@ class Module(models.Model):
 
     order = models.IntegerField()
 
+    #should run on normal validate
     def validate_options(self):
         jsonschema.validate(self.options, self.type.schema)
         return True
 
+    #should run on normal validate
     def validate_query_parameters(self):
         jsonschema.validate(self.query_parameters, query_param_schema)
         return True

--- a/stagecraft/apps/dashboards/tests/models/test_module.py
+++ b/stagecraft/apps/dashboards/tests/models/test_module.py
@@ -32,7 +32,7 @@ class ModuleTypeTestCase(TestCase):
     def test_schema_validation(self):
         module_type = ModuleType(
             name='foo',
-            schema={"type": "some made up type"}
+            schema={'properties': 'true'}
         )
         assert_that(
             calling(module_type.validate_schema),

--- a/stagecraft/apps/dashboards/tests/views/test_module.py
+++ b/stagecraft/apps/dashboards/tests/views/test_module.py
@@ -31,9 +31,10 @@ class ModuleViewsTestCase(TestCase):
                 'properties': {
                     'thing': {
                         'type': 'string',
-                    },
+                        'required': True
+                    }
                 },
-                'required': ['thing'],
+                '$schema': "http://json-schema.org/draft-03/schema#"
             }
         )
 
@@ -596,7 +597,7 @@ class ModuleTypeViewsTestCase(TestCase):
             '/module-type',
             data=json.dumps({
                 'name': 'a-type',
-                'schema': {'type': 'some wrong type'},
+                'schema': {'properties': 'true'},
             }),
             HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
             content_type='application/json')

--- a/tools/import_schemas/schema/module_schema.json
+++ b/tools/import_schemas/schema/module_schema.json
@@ -1,0 +1,92 @@
+{
+  "id": "/ModuleCommon",
+  "type": "object",
+  "properties": {
+    "axes": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "$ref": "#/definitions/axis"
+        },
+        "y": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/axis"
+          }
+        }
+      }
+    },
+    "axis-period": {
+      "type": "string",
+      "required": false,
+      "oneOf": [
+        {
+          "enum": [
+            "day",
+            "week",
+            "month",
+            "quarter"
+          ]
+        }
+      ]
+    },
+    "date-picker": {
+      "type": "object",
+      "required": false,
+      "properties": {
+        "start-date": {
+          "type": "string",
+          "format": "date-time",
+          "required": true
+        }
+      }
+    },
+    "value-attribute": {
+      "type": "string"
+    },
+    "classes": {
+      "type": [
+        "array",
+        "string"
+      ]
+    }
+  },
+  "definitions": {
+    "axis": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "required": true
+        },
+        "key": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "format": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "$schema": "http://json-schema.org/draft-03/schema#"
+}

--- a/tools/import_schemas/schema/modules_json/comparison_schema.json
+++ b/tools/import_schemas/schema/modules_json/comparison_schema.json
@@ -1,0 +1,106 @@
+{
+  "id": "/ModuleCommon",
+  "type": "object",
+  "properties": {
+    "axes": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "$ref": "#/definitions/axis"
+        },
+        "y": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/axis"
+          }
+        }
+      }
+    },
+    "axis-period": {
+      "type": "string",
+      "required": false,
+      "oneOf": [
+        {
+          "enum": [
+            "day",
+            "week",
+            "month",
+            "quarter"
+          ]
+        }
+      ]
+    },
+    "date-picker": {
+      "type": "object",
+      "required": false,
+      "properties": {
+        "start-date": {
+          "type": "string",
+          "format": "date-time",
+          "required": true
+        }
+      }
+    },
+    "value-attribute": {
+      "type": "string"
+    },
+    "classes": {
+      "type": [
+        "array",
+        "string"
+      ]
+    },
+    "category": {
+      "type": "string",
+      "required": true
+    },
+    "comparison": {
+      "type": "array",
+      "required": true
+    },
+    "show-line-labels": {
+      "type": "boolean"
+    },
+    "use_stack": {
+      "type": "boolean"
+    }
+  },
+  "definitions": {
+    "axis": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "required": true
+        },
+        "key": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "format": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "$schema": "http://json-schema.org/draft-03/schema#"
+}

--- a/tools/import_schemas/schema/modules_json/completion_numbers_schema.json
+++ b/tools/import_schemas/schema/modules_json/completion_numbers_schema.json
@@ -1,0 +1,93 @@
+{
+  "id": "/ModuleCommon",
+  "type": "object",
+  "properties": {
+    "axes": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "$ref": "#/definitions/axis"
+        },
+        "y": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/axis"
+          }
+        }
+      }
+    },
+    "axis-period": {
+      "type": "string",
+      "required": false,
+      "oneOf": [
+        {
+          "enum": [
+            "day",
+            "week",
+            "month",
+            "quarter"
+          ]
+        }
+      ]
+    },
+    "date-picker": {
+      "type": "object",
+      "required": false,
+      "properties": {
+        "start-date": {
+          "type": "string",
+          "format": "date-time",
+          "required": true
+        }
+      }
+    },
+    "value-attribute": {
+      "type": "string"
+    },
+    "classes": {
+      "type": [
+        "array",
+        "string"
+      ]
+    }
+  },
+  "definitions": {
+    "axis": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "required": true
+        },
+        "key": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ],
+          "required": false
+        },
+        "format": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "$schema": "http://json-schema.org/draft-03/schema#"
+}

--- a/tools/import_schemas/schema/modules_json/completion_rate_schema.json
+++ b/tools/import_schemas/schema/modules_json/completion_rate_schema.json
@@ -1,0 +1,105 @@
+{
+  "id": "/ModuleCommon",
+  "type": "object",
+  "properties": {
+    "axes": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "$ref": "#/definitions/axis"
+        },
+        "y": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/axis"
+          }
+        }
+      }
+    },
+    "axis-period": {
+      "type": "string",
+      "required": false,
+      "oneOf": [
+        {
+          "enum": [
+            "day",
+            "week",
+            "month",
+            "quarter"
+          ]
+        }
+      ]
+    },
+    "date-picker": {
+      "type": "object",
+      "required": false,
+      "properties": {
+        "start-date": {
+          "type": "string",
+          "format": "date-time",
+          "required": true
+        }
+      }
+    },
+    "value-attribute": {
+      "type": "string",
+      "required": true
+    },
+    "classes": {
+      "type": [
+        "array",
+        "string"
+      ]
+    },
+    "denominator-matcher": {
+      "type": "string",
+      "required": true
+    },
+    "numerator-matcher": {
+      "type": "string",
+      "required": true
+    },
+    "matching-attribute": {
+      "type": "string",
+      "required": true
+    }
+  },
+  "definitions": {
+    "axis": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "required": true
+        },
+        "key": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "format": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "$schema": "http://json-schema.org/draft-03/schema#"
+}

--- a/tools/import_schemas/schema/modules_json/grouped_timeseries_schema.json
+++ b/tools/import_schemas/schema/modules_json/grouped_timeseries_schema.json
@@ -1,0 +1,250 @@
+{
+  "allOf": [
+    {
+      "id": "/ModuleCommon",
+      "type": "object",
+      "properties": {
+        "axes": {
+          "type": "object",
+          "properties": {
+            "x": {
+              "$ref": "#/definitions/axis"
+            },
+            "y": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/axis"
+              }
+            }
+          }
+        },
+        "axis-period": {
+          "type": "string",
+          "required": false,
+          "oneOf": [
+            {
+              "enum": [
+                "day",
+                "week",
+                "month",
+                "quarter"
+              ]
+            }
+          ]
+        },
+        "date-picker": {
+          "type": "object",
+          "required": false,
+          "properties": {
+            "start-date": {
+              "type": "string",
+              "format": "date-time",
+              "required": true
+            }
+          }
+        },
+        "value-attribute": {
+          "type": "string"
+        },
+        "classes": {
+          "type": [
+            "array",
+            "string"
+          ]
+        }
+      },
+      "definitions": {
+        "query-params": {
+          "type": "object",
+          "properties": {
+            "period": {
+              "allOf": [
+                {
+                  "required": false
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "hour",
+                    "day",
+                    "week",
+                    "month",
+                    "quarter"
+                  ]
+                }
+              ]
+            },
+            "start_at": {
+              "type": "string",
+              "required": false
+            },
+            "end_at": {
+              "type": "string",
+              "required": false
+            },
+            "duration": {
+              "type": "integer",
+              "required": false
+            },
+            "sort_by": {
+              "type": "string",
+              "required": false
+            },
+            "group_by": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "required": false
+                },
+                {
+                  "type": "array",
+                  "required": false,
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
+            "collect": {
+              "type": "array",
+              "required": false,
+              "items": {
+                "type": "string",
+                "pattern": ":(sum|mean|set)$"
+              }
+            },
+            "filter_by": {
+              "type": "array",
+              "required": false,
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "axis": {
+          "type": "object",
+          "properties": {
+            "label": {
+              "type": "string",
+              "required": true
+            },
+            "key": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array"
+                }
+              ],
+              "required": false
+            },
+            "format": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "properties": {
+        "category": {
+          "type": "string",
+          "required": true
+        },
+        "use_stack": {
+          "type": "boolean"
+        },
+        "value-attribute": {
+          "required": true
+        },
+        "show-line-labels": {
+          "type": "boolean"
+        },
+        "line-label-links": {
+          "type": "boolean"
+        },
+        "show-total-lines": {
+          "type": "boolean"
+        },
+        "one-hundred-percent": {
+          "type": "boolean"
+        },
+        "group-mapping": {
+          "type": "object"
+        },
+        "currency": {
+          "type": "string",
+          "required": false,
+          "oneOf": [
+            {
+              "enum": [
+                "gbp"
+              ]
+            }
+          ]
+        },
+        "axes": {
+          "type": "object",
+          "properties": {
+            "y": {
+              "required": true
+            }
+          }
+        }
+      }
+    }
+  ],
+  "definitions": {
+    "axis": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "required": true
+        },
+        "key": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ],
+          "required": false
+        },
+        "format": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "$schema": "http://json-schema.org/draft-03/schema#"
+}

--- a/tools/import_schemas/schema/modules_json/journey_schema.json
+++ b/tools/import_schemas/schema/modules_json/journey_schema.json
@@ -1,0 +1,96 @@
+{
+  "id": "/ModuleCommon",
+  "type": "object",
+  "properties": {
+    "axes": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "$ref": "#/definitions/axis"
+        },
+        "y": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/axis"
+          }
+        }
+      }
+    },
+    "axis-period": {
+      "type": "string",
+      "required": false,
+      "oneOf": [
+        {
+          "enum": [
+            "day",
+            "week",
+            "month",
+            "quarter"
+          ]
+        }
+      ]
+    },
+    "date-picker": {
+      "type": "object",
+      "required": false,
+      "properties": {
+        "start-date": {
+          "type": "string",
+          "format": "date-time",
+          "required": true
+        }
+      }
+    },
+    "value-attribute": {
+      "type": "string"
+    },
+    "classes": {
+      "type": [
+        "array",
+        "string"
+      ]
+    },
+    "matching-attribute": {
+      "type": "string",
+      "required": false
+    }
+  },
+  "definitions": {
+    "axis": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "required": true
+        },
+        "key": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "format": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "$schema": "http://json-schema.org/draft-03/schema#"
+}

--- a/tools/import_schemas/schema/modules_json/kpi_schema.json
+++ b/tools/import_schemas/schema/modules_json/kpi_schema.json
@@ -1,0 +1,172 @@
+{
+  "id": "/ModuleCommon",
+  "type": "object",
+  "properties": {
+    "axes": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "$ref": "#/definitions/axis"
+        },
+        "y": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/axis"
+          }
+        }
+      }
+    },
+    "axis-period": {
+      "type": "string",
+      "required": false,
+      "oneOf": [
+        {
+          "enum": [
+            "day",
+            "week",
+            "month",
+            "quarter"
+          ]
+        }
+      ]
+    },
+    "date-picker": {
+      "type": "object",
+      "required": false,
+      "properties": {
+        "start-date": {
+          "type": "string",
+          "format": "date-time",
+          "required": true
+        }
+      }
+    },
+    "value-attribute": {
+      "type": "string",
+      "required": true
+    },
+    "classes": {
+      "type": [
+        "array",
+        "string"
+      ]
+    },
+    "format": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": true,
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "number"
+              ]
+            },
+            "magnitude": {
+              "type": "boolean"
+            },
+            "sigfigs": {
+              "type": "integer"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": true,
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "currency"
+              ]
+            },
+            "magnitude": {
+              "type": "boolean"
+            },
+            "sigfigs": {
+              "type": "integer"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": true,
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "currency"
+              ]
+            },
+            "dps": {
+              "type": "integer"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": true,
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "currency"
+              ]
+            },
+            "pence": {
+              "type": "boolean"
+            }
+          }
+        }
+      ],
+      "required": true
+    },
+    "date-period": {
+      "type": "string",
+      "required": false
+    }
+  },
+  "definitions": {
+    "axis": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "required": true
+        },
+        "key": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "format": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "$schema": "http://json-schema.org/draft-03/schema#"
+}

--- a/tools/import_schemas/schema/modules_json/list_schema.json
+++ b/tools/import_schemas/schema/modules_json/list_schema.json
@@ -1,0 +1,104 @@
+{
+  "id": "/ModuleCommon",
+  "type": "object",
+  "properties": {
+    "axes": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "$ref": "#/definitions/axis"
+        },
+        "y": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/axis"
+          }
+        }
+      }
+    },
+    "axis-period": {
+      "type": "string",
+      "required": false,
+      "oneOf": [
+        {
+          "enum": [
+            "day",
+            "week",
+            "month",
+            "quarter"
+          ]
+        }
+      ]
+    },
+    "date-picker": {
+      "type": "object",
+      "required": false,
+      "properties": {
+        "start-date": {
+          "type": "string",
+          "format": "date-time",
+          "required": true
+        }
+      }
+    },
+    "value-attribute": {
+      "type": "string"
+    },
+    "classes": {
+      "type": [
+        "array",
+        "string"
+      ]
+    },
+    "label-attr": {
+      "type": "string",
+      "required": true
+    },
+    "label-regex": {
+      "type": "string",
+      "required": true
+    },
+    "link-attr": {
+      "type": "string",
+      "required": true
+    }
+  },
+  "definitions": {
+    "axis": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "required": true
+        },
+        "key": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "format": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "$schema": "http://json-schema.org/draft-03/schema#"
+}

--- a/tools/import_schemas/schema/modules_json/realtime_schema.json
+++ b/tools/import_schemas/schema/modules_json/realtime_schema.json
@@ -1,0 +1,92 @@
+{
+  "id": "/ModuleCommon",
+  "type": "object",
+  "properties": {
+    "axes": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "$ref": "#/definitions/axis"
+        },
+        "y": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/axis"
+          }
+        }
+      }
+    },
+    "axis-period": {
+      "type": "string",
+      "required": false,
+      "oneOf": [
+        {
+          "enum": [
+            "day",
+            "week",
+            "month",
+            "quarter"
+          ]
+        }
+      ]
+    },
+    "date-picker": {
+      "type": "object",
+      "required": false,
+      "properties": {
+        "start-date": {
+          "type": "string",
+          "format": "date-time",
+          "required": true
+        }
+      }
+    },
+    "value-attribute": {
+      "type": "string"
+    },
+    "classes": {
+      "type": [
+        "array",
+        "string"
+      ]
+    }
+  },
+  "definitions": {
+    "axis": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "required": true
+        },
+        "key": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "format": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "$schema": "http://json-schema.org/draft-03/schema#"
+}

--- a/tools/import_schemas/schema/modules_json/single_timeseries_schema.json
+++ b/tools/import_schemas/schema/modules_json/single_timeseries_schema.json
@@ -1,0 +1,128 @@
+{
+  "id": "/ModuleCommon",
+  "type": "object",
+  "properties": {
+    "axes": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "$ref": "#/definitions/axis"
+        },
+        "y": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/axis"
+          }
+        }
+      }
+    },
+    "axis-period": {
+      "type": "string",
+      "required": false,
+      "oneOf": [
+        {
+          "enum": [
+            "day",
+            "week",
+            "month",
+            "quarter"
+          ]
+        }
+      ]
+    },
+    "date-picker": {
+      "type": "object",
+      "required": false,
+      "properties": {
+        "start-date": {
+          "type": "string",
+          "format": "date-time",
+          "required": true
+        }
+      }
+    },
+    "value-attribute": {
+      "type": "string",
+      "required": true
+    },
+    "classes": {
+      "type": [
+        "array",
+        "string"
+      ]
+    },
+    "format-options": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": false,
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "duration"
+              ]
+            },
+            "unit": {
+              "type": "string",
+              "enum": [
+                "m"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "denominator-matcher": {
+      "type": "string"
+    },
+    "numerator-matcher": {
+      "type": "string"
+    },
+    "matching-attribute": {
+      "type": "string"
+    },
+    "default-value": {
+      "type": "integer"
+    }
+  },
+  "definitions": {
+    "axis": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "required": true
+        },
+        "key": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "format": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "$schema": "http://json-schema.org/draft-03/schema#"
+}

--- a/tools/import_schemas/schema/modules_json/tab_schema.json
+++ b/tools/import_schemas/schema/modules_json/tab_schema.json
@@ -1,0 +1,22 @@
+{
+  "id": "/ModuleTab",
+  "type": "object",
+  "properties": {
+    "tabs": {
+      "type": "array",
+      "required": true,
+      "minItems": 2,
+      "items": {
+        "properties": {
+          "slug": {
+            "type": "string",
+            "required": true,
+            "maxLength": 30,
+            "pattern": "^[-a-z0-9]+$"
+          }
+        }
+      }
+    }
+  },
+  "$schema": "http://json-schema.org/draft-03/schema#"
+}

--- a/tools/import_schemas/schema/modules_json/table_schema.json
+++ b/tools/import_schemas/schema/modules_json/table_schema.json
@@ -1,0 +1,104 @@
+{
+  "id": "/ModuleCommon",
+  "type": "object",
+  "properties": {
+    "axes": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "$ref": "#/definitions/axis"
+        },
+        "y": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/axis"
+          }
+        }
+      }
+    },
+    "axis-period": {
+      "type": "string",
+      "required": false,
+      "oneOf": [
+        {
+          "enum": [
+            "day",
+            "week",
+            "month",
+            "quarter"
+          ]
+        }
+      ]
+    },
+    "date-picker": {
+      "type": "object",
+      "required": false,
+      "properties": {
+        "start-date": {
+          "type": "string",
+          "format": "date-time",
+          "required": true
+        }
+      }
+    },
+    "value-attribute": {
+      "type": "string"
+    },
+    "classes": {
+      "type": [
+        "array",
+        "string"
+      ]
+    },
+    "sort-order": {
+      "type": "string",
+      "required": true,
+      "enum": [
+        "ascending",
+        "descending"
+      ]
+    },
+    "sort-by": {
+      "type": "string",
+      "required": true
+    }
+  },
+  "definitions": {
+    "axis": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "required": true
+        },
+        "key": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "format": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "$schema": "http://json-schema.org/draft-03/schema#"
+}

--- a/tools/import_schemas/schema/modules_json/user_satisfaction_graph_schema.json
+++ b/tools/import_schemas/schema/modules_json/user_satisfaction_graph_schema.json
@@ -1,0 +1,96 @@
+{
+  "id": "/ModuleCommon",
+  "type": "object",
+  "properties": {
+    "axes": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "$ref": "#/definitions/axis"
+        },
+        "y": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/axis"
+          }
+        }
+      }
+    },
+    "axis-period": {
+      "type": "string",
+      "required": false,
+      "oneOf": [
+        {
+          "enum": [
+            "day",
+            "week",
+            "month",
+            "quarter"
+          ]
+        }
+      ]
+    },
+    "date-picker": {
+      "type": "object",
+      "required": false,
+      "properties": {
+        "start-date": {
+          "type": "string",
+          "format": "date-time",
+          "required": true
+        }
+      }
+    },
+    "value-attribute": {
+      "type": "string",
+      "required": true
+    },
+    "classes": {
+      "type": [
+        "array",
+        "string"
+      ]
+    },
+    "trim": {
+      "type": "boolean"
+    }
+  },
+  "definitions": {
+    "axis": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "required": true
+        },
+        "key": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "format": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "$schema": "http://json-schema.org/draft-03/schema#"
+}

--- a/tools/import_schemas/schema/modules_json/user_satisfaction_schema.json
+++ b/tools/import_schemas/schema/modules_json/user_satisfaction_schema.json
@@ -1,0 +1,93 @@
+{
+  "id": "/ModuleCommon",
+  "type": "object",
+  "properties": {
+    "axes": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "$ref": "#/definitions/axis"
+        },
+        "y": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/axis"
+          }
+        }
+      }
+    },
+    "axis-period": {
+      "type": "string",
+      "required": false,
+      "oneOf": [
+        {
+          "enum": [
+            "day",
+            "week",
+            "month",
+            "quarter"
+          ]
+        }
+      ]
+    },
+    "date-picker": {
+      "type": "object",
+      "required": false,
+      "properties": {
+        "start-date": {
+          "type": "string",
+          "format": "date-time",
+          "required": true
+        }
+      }
+    },
+    "value-attribute": {
+      "type": "string",
+      "required": true
+    },
+    "classes": {
+      "type": [
+        "array",
+        "string"
+      ]
+    }
+  },
+  "definitions": {
+    "axis": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "required": true
+        },
+        "key": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "format": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "$schema": "http://json-schema.org/draft-03/schema#"
+}


### PR DESCRIPTION
To consider:
- Should the module types without a specific schema default to module - **yes - it does in spotlight**
- What's up with tabs? Why is there not availability type? - **tabs seems to contain all the availability modules, perhaps we can leave this for now and handle validating sub modules in tables as a tech debt story (already created).**
- Solihull is wrong - **Use this json:**

```
{"axes": {"y": [{"label": "Reports last week", "key": "missed_bins:sum", "format": "integer"}, {"label": "Percentage of total reports", "key": "percentOfTotal(missed_bins:sum)", "format": "percent"}, {"label": "Change since previous week", "key": "delta(missed_bins:sum)", "format": {"showSigns": true, "type": "percent"}}], "x": {"key": "ward", "label": "Ward"}}, "sort-by": "ward", "sort-order": "ascending"}
```
- hmrc-prototypes-hmrc-operations is wrong - **delete empty module**
- Add validation on the validate method - not as part of the api - **Later**
- what does clearer errors mean? - **Later**
- continue with draft3? - **Yes, though it's pretty lenient about what a valid schema is...**
