### PR TITLE
Add `collect=count` to allowed module query params

### DIFF
--- a/stagecraft/apps/dashboards/models/module.py
+++ b/stagecraft/apps/dashboards/models/module.py
@@ -176,7 +176,7 @@ query_param_schema = {
             "type": "array",
             "items": {
                 "type": "string",
-                "pattern": ":(sum|mean|set)$"
+                "pattern": ":(sum|mean|set|count)$"
             }
         },
         "filter_by": {


### PR DESCRIPTION
`count` is a valid argument to pass to the collect query parameter, so Stagecraft should allow it to be part of the Module model.

This change is to let @theotherurmy do things in the admin app.
