### PR TITLE
SQL to find dashboard with certain module

### DIFF
--- a/tools/find_dashboards_with_module.sql
+++ b/tools/find_dashboards_with_module.sql
@@ -1,0 +1,10 @@
+/* find module type id */
+SELECT id FROM dashboards_moduletype where name like '%bar%';
+/* find all dashboards with this module */
+SELECT dashboards_dashboard.slug, 
+       dashboards_module.slug 
+FROM   dashboards_dashboard 
+       JOIN dashboards_module 
+         ON dashboards_dashboard.id = dashboards_module.dashboard_id 
+WHERE  dashboards_module.type_id = '99d99ec4-0f39-4e8a-8168-fc5fc783ca5b' 
+LIMIT  10; 


### PR DESCRIPTION
I needed to find a dashboard containing the bar chart with number module - I 
wrote some quick sql to find this, and wanted a place to document it.

There might be a better place to document this, or it might be so one off its
not useful to merge, but raising the PR for discussion.
