### PR TITLE
Pass client_id through to user.json

### DIFF
--- a/stagecraft/libs/authorization/http.py
+++ b/stagecraft/libs/authorization/http.py
@@ -32,7 +32,8 @@ def _get_user(access_token):
 @statsd.timer('get_user.signon')
 def _get_user_from_signon(access_token):
     response = requests.get(
-        '{0}/user.json'.format(settings.SIGNON_URL),
+        '{0}/user.json?client_id={1}'.format(
+            settings.SIGNON_URL, settings.SIGNON_CLIENT_ID),
         headers={'Authorization': 'Bearer {0}'.format(access_token)}
     )
     if response.status_code == 200:

--- a/stagecraft/settings/development.py
+++ b/stagecraft/settings/development.py
@@ -28,6 +28,7 @@ APP_ROOT = 'http://{0}'.format(APP_HOSTNAME)
 GOVUK_ROOT = 'http://spotlight.development.performance.service.gov.uk'
 
 SIGNON_URL = 'http://signon.dev.gov.uk'
+SIGNON_CLIENT_ID = 'clientid'
 USE_DEVELOPMENT_USERS = True
 DEVELOPMENT_USERS = {
     'development-oauth-access-token':


### PR DESCRIPTION
Signonotron2 requires you to pass the client_id through to the user.json
endpoint so that you can't use any apps token to gain access.

https://github.com/alphagov/signonotron2/blob/a2b3326de954300911d984aa1d191c71700846e9/test/integration/api_authentication_test.rb#L18
