### PR TITLE
Use an HttpResponseBadRequest to return HTTP error

### DIFF
--- a/stagecraft/apps/dashboards/views/dashboard.py
+++ b/stagecraft/apps/dashboards/views/dashboard.py
@@ -240,7 +240,7 @@ def dashboard(user, request, identifier=None):
                     'errors': [create_error(request, 400,
                                             detail=e.message)]
                 }
-                return HttpResponse(to_json(error), status=400)
+                return HttpResponseBadRequest(to_json(error))
 
         Module.objects.filter(id__in=module_ids).delete()
 


### PR DESCRIPTION
Even with status=400 we were seeing 200 responses coming back from
nested module updating. Everywhere else we use HttpResponseBadRequest
to indicate a 400.

Fixes #264
