### PR TITLE
Fix thread-safety issue in stagecraft

### DIFF
--- a/stagecraft/libs/request_logger/middleware.py
+++ b/stagecraft/libs/request_logger/middleware.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 class RequestLoggerMiddleware(object):
     def process_request(self, request):
-        self.request_time = time.time()
+        request.start_request_time = time.time()
         logger.info("{method} {path}".format(
             method=request.method,
             path=request.get_full_path()),
@@ -22,17 +22,18 @@ class RequestLoggerMiddleware(object):
             })
 
     def process_response(self, request, response):
-        elapsed_time = time.time() - self.request_time
-        logger.info("{method} {path} : {status} {secs:.6f}s".format(
-            method=request.method,
-            path=request.get_full_path(),
-            status=response.status_code,
-            secs=elapsed_time),
-            extra={
-                'request_method': request.method,
-                'http_host': request.META.get('HTTP_HOST'),
-                'http_path': request.get_full_path(),
-                'status': response.status_code,
-                'request_time': elapsed_time,
-            })
+        if hasattr(request, 'start_request_time'):
+            elapsed_time = time.time() - request.start_request_time
+            logger.info("{method} {path} : {status} {secs:.6f}s".format(
+                method=request.method,
+                path=request.get_full_path(),
+                status=response.status_code,
+                secs=elapsed_time),
+                extra={
+                    'request_method': request.method,
+                    'http_host': request.META.get('HTTP_HOST'),
+                    'http_path': request.get_full_path(),
+                    'status': response.status_code,
+                    'request_time': elapsed_time,
+                })
         return response


### PR DESCRIPTION
Django middleware is not thread-safe. We should store this context on
the request object instance.
