### PR TITLE
Allow cross-origin resource sharing on dashboards

### DIFF
--- a/stagecraft/apps/dashboards/tests/views/test_dashboard.py
+++ b/stagecraft/apps/dashboards/tests/views/test_dashboard.py
@@ -93,6 +93,13 @@ class DashboardViewsListTestCase(TestCase):
                                                         'my_first_slug'))
         assert_that(resp['Cache-Control'], equal_to('max-age=300'))
 
+    def test_public_dashboard_endpoint_has_cors_allowed(self):
+        DashboardFactory(slug='my-dashboard')
+
+        resp = self.client.get(
+            '/public/dashboards', {'slug': 'my-dashboard'})
+        assert_that(resp['Access-Control-Allow-Origin'], equal_to('*'))
+
     def test_get_dashboards_only_caches_when_published(self):
         DashboardFactory(slug='published_dashboard')
         DashboardFactory(slug='unpublished_dashboard', published=False)

--- a/stagecraft/apps/dashboards/views/dashboard.py
+++ b/stagecraft/apps/dashboards/views/dashboard.py
@@ -52,6 +52,8 @@ def single_dashboard_for_spotlight(request, dashboard_slug):
 
     response = HttpResponse(json_str, content_type='application/json')
 
+    response['Access-Control-Allow-Origin'] = '*'
+
     if dashboard.published:
         response['Cache-Control'] = 'max-age=300'
     else:


### PR DESCRIPTION
The public dashboard endpoint should allow requests from everywhere, for example the performanceplatform-big-screen-view.

This pull request is to enable work that @easternbloc and @jonnywyatt are doing.
