### PR TITLE
Updated help text for seconds out of date

### DIFF
--- a/stagecraft/apps/datasets/models/data_set.py
+++ b/stagecraft/apps/datasets/models/data_set.py
@@ -165,11 +165,11 @@ class DataSet(models.Model):
         updated. If this is left blank the data-set will not be monitored.<br/>
         Commonly used values are:<br/>
         - <strong>360</strong> (every 5 minutes)<br/>
-        - <strong>4500</strong> (hourly)<br/>
-        - <strong>90000</strong> (daily)<br/>
-        - <strong>648000</strong> (weekly)<br/>
-        - <strong>2764800</strong> (monthly)<br/>
-        - <strong>8467200</strong> (quarterly)<br/>
+        - <strong>9000</strong> (for hourly data)<br/>
+        - <strong>180000</strong> (for daily data)<br/>
+        - <strong>1300000</strong> (for weekly data)<br/>
+        - <strong>5200000</strong> (for monthly data)<br/>
+        - <strong>15600000</strong> (for quarterly data)<br/>
         You can choose your own value if the ones above don't work for your
         case.
         """


### PR DESCRIPTION
The way we calculate out of date data is based on the timestamp at the start of the period. The current defaults in stagecraft help text show the number of seconds of the period the data represents. This means the alerts start firing before the data is technically out of date. I have doubled the values so that the the correct values are entered when creating new datasets
