### PR TITLE
Remove authentication requirement for GETs on transforms

### DIFF
--- a/stagecraft/apps/datasets/views/data_set.py
+++ b/stagecraft/apps/datasets/views/data_set.py
@@ -41,9 +41,8 @@ def detail(user, request, name):
     return HttpResponse(json_str, content_type='application/json')
 
 
-@permission_required('transforms')
 @never_cache
-def transform(user, request, name):
+def transform(request, name):
     try:
         data_set = DataSet.objects.get(name=name)
     except DataSet.DoesNotExist:


### PR DESCRIPTION
This allows retrieval (but not modification) of data set transforms without authentication.
