### PR TITLE
Bugfix for getting transforms returning unrelated

### DIFF
--- a/stagecraft/apps/datasets/tests/views/test_data_set.py
+++ b/stagecraft/apps/datasets/tests/views/test_data_set.py
@@ -134,6 +134,39 @@ class DataSetsViewsTestCase(TestCase):
             resp_json,
             has_item(has_entry('id', str(type_transform.id))))
 
+    def test_list_transforms_for_dataset_and_type_with_no_group(self):
+        data_set = DataSetFactory()
+        another_data_set = DataSetFactory(
+            data_type=data_set.data_type,
+        )
+        set_transform = TransformFactory(
+            input_group=data_set.data_group,
+            input_type=data_set.data_type,
+        )
+        another_set_transform = TransformFactory(
+            input_group=another_data_set.data_group,
+            input_type=another_data_set.data_type,
+        )
+        type_transform = TransformFactory(
+            input_type=data_set.data_type,
+        )
+
+        resp = self.client.get(
+            '/data-sets/{}/transform'.format(data_set.name),
+            HTTP_AUTHORIZATION='Bearer development-oauth-access-token')
+
+        assert_that(resp.status_code, is_(200))
+
+        resp_json = json.loads(resp.content)
+
+        assert_that(len(resp_json), is_(2))
+        assert_that(
+            resp_json,
+            has_item(has_entry('id', str(set_transform.id))))
+        assert_that(
+            resp_json,
+            has_item(has_entry('id', str(type_transform.id))))
+
     def test_list_vary_on_authorization_header(self):
         resp = self.client.get(
             '/data-sets',

--- a/stagecraft/apps/datasets/views/data_set.py
+++ b/stagecraft/apps/datasets/views/data_set.py
@@ -58,6 +58,7 @@ def transform(request, name):
         input_group=data_set.data_group,
         input_type=data_set.data_type)
     data_type_transforms = Transform.objects.filter(
+        input_group=None,
         input_type=data_set.data_type)
 
     transforms = data_set_transforms | data_type_transforms


### PR DESCRIPTION
When we get the transforms for a dataset we also want to get any
transforms that just have a data type. At the moment because the
filtering is incorrect it will get the transforms for any other data set
that has the same type.
