### PR TITLE
Make group_by consistently a list

### DIFF
--- a/requirements/_testing.txt
+++ b/requirements/_testing.txt
@@ -6,7 +6,7 @@ nose-exclude==0.2.0
 mock>=1.0
 
 django-nose==1.2
-pep8==1.4.5
+pep8==1.5.7
 coverage==3.6
 PyHamcrest==1.8.0
 

--- a/stagecraft/apps/dashboards/migrations/0007_consistent_group_by_array.py
+++ b/stagecraft/apps/dashboards/migrations/0007_consistent_group_by_array.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+from south.v2 import SchemaMigration
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        def modifiedQueryParameters(module):
+            if module.query_parameters is None:
+                return False
+
+            json = module.query_parameters
+            group_by = json.get('group_by')
+
+            if group_by is None or type(group_by) is list:
+                return False
+
+            # we have a group_by that isn't a list. Update it.
+            json['group_by'] = [group_by]
+            module.query_parameters = json
+
+            return True
+
+        for module in orm['dashboards.Module'].objects.all():
+            if modifiedQueryParameters(module):
+                module.save()
+
+    def backwards(self, orm):
+        # This migration should be safe and idempotent, so
+        # not raising an error here.
+        pass
+
+    models = {
+        'dashboards.dashboard': {
+            'Meta': {'object_name': 'Dashboard'},
+            'business_model': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '31', 'blank': 'True'}),
+            'costs': ('django.db.models.fields.CharField', [], {'max_length': '1500', 'blank': 'True'}),
+            'customer_type': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '20', 'blank': 'True'}),
+            'dashboard_type': ('django.db.models.fields.CharField', [], {'default': "'transaction'", 'max_length': '30'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'description_extra': ('django.db.models.fields.CharField', [], {'max_length': '400', 'blank': 'True'}),
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'improve_dashboard_message': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'organisation': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Node']", 'null': 'True', 'blank': 'True'}),
+            'other_notes': ('django.db.models.fields.CharField', [], {'max_length': '1000', 'blank': 'True'}),
+            'page_type': ('django.db.models.fields.CharField', [], {'default': "'dashboard'", 'max_length': '80'}),
+            'published': ('django.db.models.fields.BooleanField', [], {}),
+            'slug': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '90'}),
+            'strapline': ('django.db.models.fields.CharField', [], {'default': "'Dashboard'", 'max_length': '40'}),
+            'tagline': ('django.db.models.fields.CharField', [], {'max_length': '400', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'dashboards.link': {
+            'Meta': {'object_name': 'Link'},
+            'dashboard': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dashboards.Dashboard']"}),
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'link_type': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        'dashboards.module': {
+            'Meta': {'unique_together': "(('dashboard', 'slug'),)", 'object_name': 'Module'},
+            'dashboard': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dashboards.Dashboard']"}),
+            'data_set': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['datasets.DataSet']", 'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'info': ('dbarray.fields.TextArrayField', [], {'blank': 'True'}),
+            'options': ('jsonfield.fields.JSONField', [], {'blank': 'True'}),
+            'order': ('django.db.models.fields.IntegerField', [], {}),
+            'query_parameters': ('jsonfield.fields.JSONField', [], {'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '60'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '60'}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dashboards.ModuleType']"})
+        },
+        'dashboards.moduletype': {
+            'Meta': {'object_name': 'ModuleType'},
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '25'}),
+            'schema': ('jsonfield.fields.JSONField', [], {})
+        },
+        u'datasets.datagroup': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'DataGroup'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        u'datasets.dataset': {
+            'Meta': {'ordering': "[u'name']", 'unique_together': "([u'data_group', u'data_type'],)", 'object_name': 'DataSet'},
+            'auto_ids': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'bearer_token': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'capped_size': ('django.db.models.fields.PositiveIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'data_group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['datasets.DataGroup']", 'on_delete': 'models.PROTECT'}),
+            'data_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['datasets.DataType']", 'on_delete': 'models.PROTECT'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'max_age_expected': ('django.db.models.fields.PositiveIntegerField', [], {'default': '86400', 'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '200'}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'queryable': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'raw_queries_allowed': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'realtime': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'upload_filters': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'upload_format': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        u'datasets.datatype': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'DataType'},
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        u'organisation.node': {
+            'Meta': {'object_name': 'Node'},
+            'abbreviation': ('django.db.models.fields.CharField', [], {'max_length': '50', 'unique': 'True', 'null': 'True'}),
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            u'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '256'}),
+            'parent': ('mptt.fields.TreeForeignKey', [], {'blank': 'True', 'related_name': "'children'", 'null': 'True', 'to': u"orm['organisation.Node']"}),
+            u'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'typeOf': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.NodeType']"})
+        },
+        u'organisation.nodetype': {
+            'Meta': {'object_name': 'NodeType'},
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '256'})
+        }
+    }
+
+    complete_apps = ['dashboards']

--- a/stagecraft/apps/dashboards/tests/models/test_module.py
+++ b/stagecraft/apps/dashboards/tests/models/test_module.py
@@ -289,3 +289,62 @@ class ModuleTestCase(TestCase):
             calling(lambda: module.validate_options()),
             raises(ValidationError)
         )
+
+    def test_group_by_is_rewritten_to_be_a_list(self):
+        module = Module.objects.create(
+            title='a-title',
+            slug='a-module',
+            type=self.module_type,
+            dashboard=self.dashboard_a,
+            data_set=self.data_set,
+            order=1,
+            options={
+                'foo': 'bar',
+            },
+            query_parameters={
+                'group_by': 'foo'
+            })
+
+        module.full_clean()
+
+        assert_that(module.query_parameters['group_by'],
+                    equal_to(['foo']))
+
+    def test_list_group_by_is_unchanged(self):
+        module = Module.objects.create(
+            title='a-title',
+            slug='a-module',
+            type=self.module_type,
+            dashboard=self.dashboard_a,
+            data_set=self.data_set,
+            order=1,
+            options={
+                'foo': 'bar',
+            },
+            query_parameters={
+                'group_by': ['foo']
+            })
+
+        module.full_clean()
+
+        assert_that(module.query_parameters['group_by'],
+                    equal_to(['foo']))
+
+    def test_no_group_by_is_unchanged(self):
+        module = Module.objects.create(
+            title='a-title',
+            slug='a-module',
+            type=self.module_type,
+            dashboard=self.dashboard_a,
+            data_set=self.data_set,
+            order=1,
+            options={
+                'foo': 'bar',
+            },
+            query_parameters={}
+        )
+
+        module.full_clean()
+
+        assert_that(module.query_parameters.get('group_by'),
+                    equal_to(None))

--- a/stagecraft/libs/schemas/schemas.py
+++ b/stagecraft/libs/schemas/schemas.py
@@ -19,7 +19,7 @@ def get_defined_schemas(name=None):
 
 def load_json_schema(schema_path):
 
-    if not ".json" in schema_path:
+    if ".json" not in schema_path:
         schema_path = schema_path + ".json"
 
     schema_path = path.join(schema_root, schema_path)


### PR DESCRIPTION
Data migration — make group_by consistently a list

This makes it easier for clients to work with. In particular, languages
like Go which are statically-typed.

Rewrite group_by to be a list when writing to DB

Also bump pep8 to support long URLs in comments, and make related pep8
changes.

See https://www.agileplannerapp.com/boards/15088/cards/9043