### PR TITLE
Increase size of datatype name field

### DIFF
--- a/stagecraft/apps/datasets/migrations/0014_auto__chg_field_datatype_name.py
+++ b/stagecraft/apps/datasets/migrations/0014_auto__chg_field_datatype_name.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'DataType.name'
+        db.alter_column(u'datasets_datatype', 'name', self.gf('django.db.models.fields.SlugField')(unique=True, max_length=60))
+
+    def backwards(self, orm):
+
+        # Changing field 'DataType.name'
+        db.alter_column(u'datasets_datatype', 'name', self.gf('django.db.models.fields.SlugField')(max_length=50, unique=True))
+
+    models = {
+        u'datasets.backdropuser': {
+            'Meta': {'ordering': "[u'email']", 'object_name': 'BackdropUser'},
+            'data_sets': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['datasets.DataSet']", 'symmetrical': 'False', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'unique': 'True', 'max_length': '254'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'datasets.datagroup': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'DataGroup'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        u'datasets.dataset': {
+            'Meta': {'ordering': "[u'name']", 'unique_together': "([u'data_group', u'data_type'],)", 'object_name': 'DataSet'},
+            'auto_ids': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'bearer_token': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'capped_size': ('django.db.models.fields.PositiveIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'data_group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['datasets.DataGroup']", 'on_delete': 'models.PROTECT'}),
+            'data_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['datasets.DataType']", 'on_delete': 'models.PROTECT'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'max_age_expected': ('django.db.models.fields.PositiveIntegerField', [], {'default': '86400', 'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '200'}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'queryable': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'raw_queries_allowed': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'realtime': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'upload_filters': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'upload_format': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        u'datasets.datatype': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'DataType'},
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '60'})
+        },
+        u'datasets.oauthuser': {
+            'Meta': {'object_name': 'OAuthUser'},
+            'access_token': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'expires_at': ('django.db.models.fields.DateTimeField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'permissions': ('dbarray.fields.CharArrayField', [], {'max_length': '255'}),
+            'uid': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['datasets']

--- a/stagecraft/apps/datasets/models/data_type.py
+++ b/stagecraft/apps/datasets/models/data_type.py
@@ -8,7 +8,7 @@ from ..helpers.validators import data_type_name_validator
 
 @python_2_unicode_compatible
 class DataType(models.Model):
-    name = models.SlugField(max_length=50, unique=True,
+    name = models.SlugField(max_length=60, unique=True,
                             validators=[data_type_name_validator])
     description = models.TextField(blank=True)
 


### PR DESCRIPTION
This is due to running transform migrations. We want to create a
transform type for the module
g-cloud/proportion-of-sales-from-small-and-medium-enterprises
and use the module slug as the data type name. This is 53 characters,
but setting the limit to 60 chars as it is a round number and shouldnt
hit the limit on mongo collection names which is 128 characters