### PR TITLE
Add superuser to stagecraft on dev vm

### DIFF
--- a/tools/replicate-db.sh
+++ b/tools/replicate-db.sh
@@ -60,6 +60,7 @@ then
     vagrant ssh development-1 -c "cd /var/apps/stagecraft/tools && sudo su postgres -c \"gunzip -c ${FILENAME} | psql\" -- -t"
     vagrant ssh development-1 -c "cd /var/apps/stagecraft/tools && sudo service collectd start"
     vagrant ssh development-1 -c "sudo su postgres -c \"psql -c \\\"ALTER ROLE stagecraft WITH PASSWORD 'securem8'\\\"\" -- -t"
+    vagrant ssh development-1 -c "sudo su postgres -c \"psql -c \\\"ALTER ROLE stagecraft WITH SUPERUSER\\\"\" -- -t"
     popd
 else
     echo "Remote restore has not been implemented yet."


### PR DESCRIPTION
The stagecraft user on the dev vm needs to be able to create a database
for the test runs, the permissions the user has copied down from
preview/staging/prod does not allow it to do this.