### PR TITLE
Route to get dashboards by tx service id

### DIFF
--- a/stagecraft/apps/dashboards/tests/views/test_transactions_explorer.py
+++ b/stagecraft/apps/dashboards/tests/views/test_transactions_explorer.py
@@ -1,0 +1,115 @@
+import json
+
+from django.test import TestCase
+from hamcrest import (
+    assert_that, equal_to, is_,
+    has_entry, has_item, has_key, is_not, has_length
+)
+
+from stagecraft.libs.backdrop_client import disable_backdrop_connection
+from ...models import Dashboard, Module, ModuleType
+
+from stagecraft.apps.dashboards.tests.factories.factories import(
+    DashboardFactory,
+    ModuleFactory,
+    ModuleTypeFactory)
+
+from stagecraft.apps.datasets.tests.factories import(
+    DataGroupFactory,
+    DataTypeFactory,
+    DataSetFactory)
+
+
+class TransactionsExplorerViewsTestCase(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.data_group = DataGroupFactory(
+            name='transactional-services',
+        )
+        cls.data_type = DataTypeFactory(
+            name='summaries',
+        )
+        cls.data_set = DataSetFactory(
+            data_group=cls.data_group,
+            data_type=cls.data_type,
+        )
+
+    @classmethod
+    @disable_backdrop_connection
+    def tearDownClass(cls):
+        cls.data_set.delete()
+        cls.data_type.delete()
+        cls.data_group.delete()
+
+    def build_dashboard(self, published=True, filter_by=[]):
+        dashboard = DashboardFactory(
+            published=published,
+        )
+        module = ModuleFactory(
+            dashboard=dashboard,
+            data_set=self.data_set,
+            query_parameters={
+                'filter_by': filter_by,
+            },
+        )
+
+        return dashboard
+
+    def test_dashboard_by_tx(self):
+        dashboard = self.build_dashboard(
+            published=True,
+            filter_by=['service_id:hmrc-tax', 'foo:bar'],
+        )
+        resp = self.client.get(
+            '/transactions-explorer-service/hmrc-tax/dashboard')
+
+        assert_that(resp.status_code, is_(200))
+
+        resp_json = json.loads(resp.content)
+
+        assert_that(len(resp_json), is_(1))
+        assert_that(resp_json[0]['slug'], is_(dashboard.slug))
+
+    def test_dashboard_by_tx_no_unpublished(self):
+        dashboard = self.build_dashboard(
+            published=False,
+            filter_by=['service_id:hmrc-tax'],
+        )
+        resp = self.client.get(
+            '/transactions-explorer-service/hmrc-tax/dashboard')
+
+        assert_that(resp.status_code, is_(200))
+
+        resp_json = json.loads(resp.content)
+
+        assert_that(len(resp_json), is_(0))
+
+    def test_dashboard_by_tx_wrong_id(self):
+        dashboard = self.build_dashboard(
+            published=False,
+            filter_by=['service_id:dft-driving'],
+        )
+        resp = self.client.get(
+            '/transactions-explorer-service/hmrc-tax/dashboard')
+
+        assert_that(resp.status_code, is_(200))
+
+        resp_json = json.loads(resp.content)
+
+        assert_that(len(resp_json), is_(0))
+
+    def test_dashboard_by_tx_id_not_first(self):
+        dashboard = self.build_dashboard(
+            published=True,
+            filter_by=['foo:bar', 'service_id:hmrc-tax'],
+        )
+        resp = self.client.get(
+            '/transactions-explorer-service/hmrc-tax/dashboard')
+
+        assert_that(resp.status_code, is_(200))
+
+        resp_json = json.loads(resp.content)
+
+        assert_that(len(resp_json), is_(1))
+        assert_that(resp_json[0]['slug'], is_(dashboard.slug))

--- a/stagecraft/apps/dashboards/views/transactions_explorer.py
+++ b/stagecraft/apps/dashboards/views/transactions_explorer.py
@@ -1,0 +1,20 @@
+import json
+
+from stagecraft.libs.views.utils import to_json
+
+from django.http import HttpResponse
+from django.db import connection
+from ..models import Dashboard
+
+
+def dashboards_by_tx(request, identifier):
+    dashboards = Dashboard.objects.by_tx_id(identifier)
+
+    serialized_dashboards = \
+        [dashboard.serialize() for dashboard in dashboards]
+
+    return HttpResponse(
+        to_json(serialized_dashboards),
+        content_type='application/json',
+        status=200
+    )

--- a/stagecraft/urls.py
+++ b/stagecraft/urls.py
@@ -10,6 +10,8 @@ from stagecraft.apps.datasets.views import data_set as datasets_views
 from stagecraft.apps.datasets.views import backdrop_user as backdrop_user_views
 from stagecraft.apps.dashboards.views import dashboard as dashboard_views
 from stagecraft.apps.dashboards.views import module as module_views
+from stagecraft.apps.dashboards.views import \
+    transactions_explorer as transactions_explorer_views
 
 from stagecraft.libs.views.resource import resource_url
 from stagecraft.libs.status import views as status_views
@@ -77,6 +79,9 @@ urlpatterns = patterns(
         module_views.modules_on_dashboard),
     url(r'^dashboard/(?P<identifier>[-a-z0-9]+)$',
         dashboard_views.dashboard, name='dashboard'),
+
+    url(r'^transactions-explorer-service/(?P<identifier>[-a-z0-9]+)/dashboard',
+        transactions_explorer_views.dashboards_by_tx, name='dashboards_by_tx'),
 
     resource_url('organisation/node', organisation_views.NodeView),
     resource_url('organisation/type', organisation_views.NodeTypeView),


### PR DESCRIPTION
In order to map data from the transactions explorer dataset to the
relevant dashboard slug we need to be able to pass in a service id
and get back dashboards that use it.

The mapping from a service_id to a dashboard should be 1 to 1 as
dashboards are meant to represent services. There are unpublished
dashboards that use data for services for playing around/testing so we
filter these out to avoid making the wrong decision.