### PR TITLE
Eager load associations to speed up GET /data-sets

### DIFF
--- a/stagecraft/apps/datasets/views/data_set.py
+++ b/stagecraft/apps/datasets/views/data_set.py
@@ -84,6 +84,15 @@ class DataSetView(ResourceView):
         "additionalProperties": False,
     }
 
+    def list(self, request, **kwargs):
+        '''
+        Override ResourceView's list function (called by its 'get' function)
+        so that the retrieval of all data sets can be optimised
+        by eager loading data group and type associations.
+        '''
+        queryset = super(DataSetView, self).list(request, **kwargs)
+        return queryset.select_related('data_group', 'data_type')
+
     @method_decorator(permission_required('signin'))
     @method_decorator(never_cache)
     @method_decorator(vary_on_headers('Authorization'))

--- a/stagecraft/libs/views/resource.py
+++ b/stagecraft/libs/views/resource.py
@@ -65,9 +65,7 @@ class ResourceView(View):
         # Used to filter by, for instance, backdrop user
         filter_args = dict(filter_args.items() + additional_filters.items())
 
-        return self.model.objects.filter(
-            **filter_args).select_related(
-                'data_group', 'data_type').order_by('pk')
+        return self.model.objects.filter(**filter_args).order_by('pk')
 
     def by_id(self, request, id, user=None):
         get_args = {self.id_field: id}

--- a/stagecraft/libs/views/resource.py
+++ b/stagecraft/libs/views/resource.py
@@ -65,7 +65,9 @@ class ResourceView(View):
         # Used to filter by, for instance, backdrop user
         filter_args = dict(filter_args.items() + additional_filters.items())
 
-        return self.model.objects.filter(**filter_args).order_by('pk')
+        return self.model.objects.filter(
+            **filter_args).select_related(
+                'data_group', 'data_type').order_by('pk')
 
     def by_id(self, request, id, user=None):
         get_args = {self.id_field: id}


### PR DESCRIPTION
A small optimisation in order to speed up the retrieval of all data sets through the GET /data-sets endpoint.

This optimisation is in support of a usability improvement to the Performance Platform admin tool which requires that the admin tool makes use of the /data-sets endpoint for the first time - see https://github.com/alphagov/performanceplatform-admin/tree/select-groups-and-types  and https://www.agileplannerapp.com/boards/15088/cards/8879.

By using Django's select_related QuerySet method to eager load the data group and type associations for each data set, the overall query count is reduced significantly. This in turn reduces the time taken to retrieve all data sets. In development, the time taken to retrieve all data sets was observed to drop from circa 3.5 seconds to circa 1.2 seconds.

There is scope to reduce the time taken further by optimising the retrieval of data type schema information within the DataSet#serialize() method (its call to get_schema). This could be achieved, for example, by passing a look-up dict of schema information to the serialize method.
