### PR TITLE
Allow 'dashboard-editor' users to see all datasets

### DIFF
--- a/stagecraft/apps/datasets/tests/views/test_data_set.py
+++ b/stagecraft/apps/datasets/tests/views/test_data_set.py
@@ -322,6 +322,18 @@ class DataSetsViewsTestCase(TestCase):
             response_object = json.loads(resp.content.decode('utf-8'))
             assert_equal(len(response_object), 6)
 
+    def test_list_returns_all_data_sets_if_user_has_dashboard_editor_permission(self):  # noqa
+        settings.USE_DEVELOPMENT_USERS = False
+        signon = govuk_signon_mock(
+            permissions=['signin', 'dataset', 'dashboard-editor'])
+        with HTTMock(signon):
+            resp = self.client.get(
+                '/data-sets',
+                HTTP_AUTHORIZATION='Bearer correct-token')
+            assert_equal(resp.status_code, 200)
+            response_object = json.loads(resp.content.decode('utf-8'))
+            assert_equal(len(response_object), 6)
+
     def test_list_returns_no_data_sets_if_there_is_no_backdrop_user(self):
         settings.USE_DEVELOPMENT_USERS = False
         signon = govuk_signon_mock(permissions=['signin', 'dataset'])

--- a/stagecraft/libs/views/resource.py
+++ b/stagecraft/libs/views/resource.py
@@ -53,7 +53,10 @@ class ResourceView(View):
     def list(self, request, **kwargs):
         user = kwargs.get('user', None)
         additional_filters = kwargs.get('additional_filters', {})
-        if user and 'admin' not in user['permissions']:
+        unfiltered_roles = {'admin', 'dashboard-editor'}
+        should_filter = user and (len(set(user['permissions']).intersection(
+            unfiltered_roles)) == 0)
+        if should_filter:
             additional_filters['backdropuser'] = BackdropUser.objects.filter(
                 email=user['email'])
 


### PR DESCRIPTION
Allow users with the common dashboard-editor role to see all datasets. This is
required for the admin app to show users a list of dataset groups and
types in a dropdown list.

Although this is part of the base resource view, this should not affect
endpoints other than datasets as they are the only models that have the
backdrop_user relationship which is used for filtering.