### PR TITLE
Fix spreadsheet parsing

### DIFF
--- a/stagecraft/tools/spreadsheets.py
+++ b/stagecraft/tools/spreadsheets.py
@@ -1,84 +1,120 @@
 import gspread
 
 
-def parse_tx_row(row):
-    """
-    >>> parsed_row = parse_tx_row(['thIs', 'that', 'foo', 'Bar'])
-    >>> department = parsed_row['department']
-    >>> department == {'abbr': 'thIs', 'name': 'that', 'slug': 'this'}
-    True
-    >>> agency = parsed_row['agency']
-    >>> agency == {'abbr': 'Bar', 'name': 'foo', 'slug': 'bar'}
-    True
-    """
-    agency = {
-        'abbr': row[3],
-        'slug': row[3].lower(),
-        'name': row[2],
-    }
-    department = {
-        'abbr': row[0],
-        'slug': row[0].lower(),
-        'name': row[1],
-    }
+class SpreadsheetMunger:
 
-    if(agency['abbr'] == department['abbr']
-       or agency['name'] == department['name']):
-        agency = None
+    def __init__(self, positions={}):
+        # The transaction explorer spreadsheet is less likely to change.
+        # As a result we can assume these positions.
+        self.tx_agency_abbr = positions.get('tx_agency_abbr', 3)
+        self.tx_agency_name = positions.get('tx_agency_name', 2)
+        self.tx_department_abbr = positions.get('tx_department_abbr', 0)
+        self.tx_department_name = positions.get('tx_department_name', 1)
 
-    return {
-        'department': department,
-        'agency': agency,
-    }
+        self.tx_tx_id_column = positions.get('tx_tx_id_column', 6)
 
+        self.names_name = positions['names_name']
+        self.names_slug = positions['names_slug']
+        self.names_service_name = positions['names_service_name']
+        self.names_service_slug = positions['names_service_slug']
 
-def parse_names_row(row):
-    """
-    >>> names_row = ['', '', '', '', '', '', 'thIs', 'that', 'foo', 'Bar']
-    >>> result = parse_names_row(names_row)
-    >>> result == {'name':'thIs','service':{'name':'','slug':''},'slug':'hat'}
-    True
-    """
-    return {
-        'name': row[6],
-        'slug': row[7][1:],  # chop off leading slash
-        'service': {
-            'name': row[4],
-            'slug': row[5][1:],  # chop off leading slash
+        self.names_tx_id_column = positions['names_tx_id_column']
+
+    def _parse_tx_row(self, row):
+        """
+        >>> positions={
+        ...     'names_name': 6,
+        ...     'names_slug': 7,
+        ...     'names_service_name': 4,
+        ...     'names_service_slug': 5,
+        ...     'names_tx_id_column': 16}
+        >>> munger = SpreadsheetMunger(positions)
+        >>> parsed_row = munger._parse_tx_row(['thIs', 'that', 'foo', 'Bar'])
+        >>> department = parsed_row['department']
+        >>> department == {'abbr': 'thIs', 'name': 'that', 'slug': 'this'}
+        True
+        >>> agency = parsed_row['agency']
+        >>> agency == {'abbr': 'Bar', 'name': 'foo', 'slug': 'bar'}
+        True
+        """
+        agency = {
+            'abbr': row[self.tx_agency_abbr],
+            'slug': row[self.tx_agency_abbr].lower(),
+            'name': row[self.tx_agency_name],
         }
-    }
+        department = {
+            'abbr': row[self.tx_department_abbr],
+            'slug': row[self.tx_department_abbr].lower(),
+            'name': row[self.tx_department_name],
+        }
 
+        if(agency['abbr'] == department['abbr']
+           or agency['name'] == department['name']):
+            agency = None
 
-def _parse_rows(worksheet, parse_fn, slug_col_num):
-    return {r[slug_col_num]: parse_fn(r)
-            for r in worksheet.get_all_values()[1:]}
+        return {
+            'department': department,
+            'agency': agency,
+        }
 
+    def _parse_names_row(self, row):
+        """
+        >>> positions={
+        ...     'names_name': 6,
+        ...     'names_slug': 7,
+        ...     'names_service_name': 4,
+        ...     'names_service_slug': 5,
+        ...     'names_tx_id_column': 16}
+        >>> munger = SpreadsheetMunger(positions)
+        >>> names_row = ['', '', '', '', '', '', 'thIs', 'tha', 'foo', 'Bar']
+        >>> result = munger._parse_names_row(names_row)
+        >>> result=={'name':'thIs','service':{'name':'','slug':''},'slug':'ha'}
+        True
+        """
+        return {
+            'name': row[self.names_name],
+            'slug': row[self.names_slug][1:],  # cut leading slash
+            'service': {
+                'name': row[self.names_service_name],
+                'slug': row[self.names_service_slug][1:],  # cut leading slash
+            }
+        }
 
-def merge(tx, names):
-    merged = []
+    def _parse_rows(self, worksheet, parse_fn, tx_id_column):
+        return {r[tx_id_column]: parse_fn(r)
+                for r in worksheet.get_all_values()[1:]}
 
-    for tx_id, tx_datum in tx.items():
-        try:
-            names_datum = names[tx_id]
-            merged.append(
-                dict(list(tx_datum.items()) +
-                     list(names_datum.items()) +
-                     [('tx_id', tx_id)]))
-        except KeyError:
-            print('failed to find name info for {}'.format(tx_id))
+    def _merge(self, tx, names):
+        merged = []
 
-    return merged
+        for tx_id, tx_datum in tx.items():
+            try:
+                names_datum = names[tx_id]
+                merged.append(
+                    dict(list(tx_datum.items()) +
+                         list(names_datum.items()) +
+                         [('tx_id', tx_id)]))
+            except KeyError:
+                print('failed to find name info for {}'.format(tx_id))
 
+        return merged
 
-def load(username, password):
-    account = gspread.login(username, password)
+    def load(self, username, password):
+        account = gspread.login(username, password)
 
-    tx_worksheet = account.open_by_key(
-        '0AiLXeWvTKFmBdFpxdEdHUWJCYnVMS0lnUHJDelFVc0E').worksheet('TX_Data')
-    names_worksheet = account.open_by_key(
-        '1jwJBNgKCOn5PN_rC2VDK9iwBSaP0s7KrUjQY_Hpj-V8').worksheet('Sheet1')
+        tx_worksheet = account.open_by_key(
+            '0AiLXeWvTKFmBdFpxdEdHUWJCYnVMS0lnUHJDelFVc0E').worksheet(
+                'TX_Data')
+        names_worksheet = account.open_by_key(
+            '1jwJBNgKCOn5PN_rC2VDK9iwBSaP0s7KrUjQY_Hpj-V8').worksheet('Sheet1')
 
-    tx_data = _parse_rows(tx_worksheet, parse_tx_row, 6)
-    names_data = _parse_rows(names_worksheet, parse_names_row, 16)
+        tx_data = self._parse_rows(
+            tx_worksheet,
+            self._parse_tx_row,
+            self.tx_tx_id_column)
+        names_data = self._parse_rows(
+            names_worksheet,
+            self._parse_names_row,
+            self.names_tx_id_column)
 
-    return merge(tx_data, names_data)
+        return self._merge(tx_data, names_data)

--- a/stagecraft/tools/test_spreadsheet.py
+++ b/stagecraft/tools/test_spreadsheet.py
@@ -1,5 +1,5 @@
 from mock import patch
-from .spreadsheets import load
+from .spreadsheets import SpreadsheetMunger
 import json
 from hamcrest import (
     assert_that, equal_to
@@ -18,6 +18,13 @@ def test_load(mock_login):
         return [tx_worksheet, names_worksheet]
 
     mock_login().open_by_key().worksheet().get_all_values.side_effect = get_appropriate_spreadsheet()  # noqa
-    result = load('beep', 'boop')
+    munger = SpreadsheetMunger(positions={
+        'names_name': 6,
+        'names_slug': 7,
+        'names_service_name': 4,
+        'names_service_slug': 5,
+        'names_tx_id_column': 16
+    })
+    result = munger.load('beep', 'boop')
     with open('stagecraft/tools/fixtures/result.json', 'r') as f:
         assert_that(json.loads(f.read()), equal_to(result))

--- a/stagecraft/tools/txex-migration.py
+++ b/stagecraft/tools/txex-migration.py
@@ -11,6 +11,14 @@ except KeyError:
           "and password (GOOGLE_PASSWORD) as environment variables")
     sys.exit(1)
 
-from spreadsheets import load
+column_positions = {
+    'names_name': 7,
+    'names_slug': 8,
+    'names_service_name': 5,
+    'names_service_slug': 6,
+    'names_tx_id_column': 17
+}
+from spreadsheets import SpreadsheetMunger
 
-print load(username, password)
+munger = SpreadsheetMunger(column_positions)
+print munger.load(username, password)


### PR DESCRIPTION
This pull request fixes the spreadsheet parsing and merging for the changed column positions in the new names spreadsheet. It makes this more configureable to guard against future changes and makes the test pass independently of the configuration changes needed for the actual spreadsheet. It still uses column positions however when arguably using key based parsing (with the column headers as keys) would be more robust. If the spreadsheet keeps changing perhaps this would be a good further refactoring to carry out. 