### PR TITLE
Create low volume dashboards from transactions explorer feed

### DIFF
--- a/stagecraft/tools/import_dashboards.py
+++ b/stagecraft/tools/import_dashboards.py
@@ -1,0 +1,323 @@
+import logging
+import os
+import sys
+
+import requests
+
+from django.db import IntegrityError
+
+from .spreadsheets import SpreadsheetMunger
+
+from stagecraft.apps.dashboards.models import Dashboard
+from stagecraft.apps.dashboards.models import Module
+from stagecraft.apps.dashboards.models import ModuleType
+from stagecraft.apps.organisation.models import Node
+from stagecraft.apps.datasets.models import DataSet
+
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+handler = logging.StreamHandler()
+handler.setLevel(logging.DEBUG)
+log.addHandler(handler)
+
+
+def import_dashboards(summaries, dry_run=False):
+    try:
+        username = os.environ['GOOGLE_USERNAME']
+        password = os.environ['GOOGLE_PASSWORD']
+    except KeyError:
+        log.fatal("Please supply username (GOOGLE_USERNAME)\
+                and password (GOOGLE_PASSWORD) as environment variables")
+        sys.exit(1)
+
+    loader = SpreadsheetMunger(positions={
+        'names_name': 9,
+        'names_slug': 10,
+        'names_service_name': 11,
+        'names_service_slug': 12,
+        'names_tx_id_column': 19
+    })
+    records = loader.load_tx_worksheet(username, password)
+    log.debug('Loaded {} records'.format(len(records)))
+
+    for record in records:
+        if not record['high_volume']:
+            import_dashboard(summaries, record, dry_run)
+
+
+def import_dashboard(summaries, record, dry_run=False):
+    log.debug(record)
+    try:
+        dashboard = Dashboard.objects.get(slug=record['slug'])
+        log.debug('Retrieved dashboard: {}'.format(record['slug']))
+    except Dashboard.DoesNotExist:
+        dashboard = create_dashboard(record, dry_run)
+        log.debug('Creating dashboard: {}'.format(record['slug']))
+    dataset = get_dataset()
+    modules = []
+
+    service_data = [
+        data for data in summaries if data['service_id'] == record['slug']]
+    quarterly_data = [
+        datum for datum in service_data if datum['type'] == 'quarterly']
+    seasonal_data = [
+        datum for datum in service_data \
+                if datum['type'] == 'seasonally-adjusted']
+
+    # Order in which modules are appended is significant
+    # as it will affect how the dashboard displays.
+    modules.append(make_tpy_module(record, dashboard, dataset, dry_run))
+
+    for datum in seasonal_data:
+        if datum.get('total_cost') is not None:
+            modules.append(make_tc_module(record, dashboard, dataset, dry_run))
+            break
+
+    for datum in seasonal_data:
+        if datum.get('cost_per_transaction') is not None:
+            modules.append(
+                make_cpt_module(record, dashboard, dataset, dry_run))
+            break
+
+    modules.append(make_tpq_module(record, dashboard, dataset, dry_run))
+
+    digital_takeup = False
+    for datum in seasonal_data:
+        if datum.get('digital_takeup'):
+            digital_takeup = True
+            break
+    for datum in quarterly_data:
+        if datum.get('digital_takeup'):
+            digital_takeup = True
+            break
+    if digital_takeup:
+        modules.append(make_dtu_module(record, dashboard, dataset, dry_run))
+
+    for idx, module in enumerate(modules):
+        # Order is 1-indexed
+        module.order = idx + 1
+        if dry_run:
+            # Use any old dashboard for its UUID.
+            module.dashboard = Dashboard.objects.first()
+            module.full_clean()
+        else:
+            try:
+                module.save()
+                log.debug('Added module: {}'.format(module.slug))
+            except IntegrityError:
+                log.debug('Module already exists: {}'.format(module.slug))
+
+
+def get_dataset():
+    return DataSet.objects.get(
+        data_group__name='transactional-services',
+        data_type__name='summaries')
+
+
+def create_dashboard(record, dry_run=False):
+    """
+    Retrieve or create dashboard config for the record.
+    """
+
+    dashboard = Dashboard()
+    dashboard.title = record['name']
+    dashboard.slug = record['slug']
+    dashboard.description = record['description']
+    dashboard.description_extra = record['description_extra']
+    dashboard.costs = record['costs']
+    dashboard.other_notes = record['other_notes']
+
+    if record.get('agency'):
+        key = 'agency'
+    else:
+        key = 'department'
+    try:
+        organisation = Node.objects.get(abbreviation=record[key]['abbr'])
+    except Node.DoesNotExist:
+        if not dry_run:
+            log.warn(
+                'Organisation not found for record : {}'\
+                        .format(record['slug']))
+    if record['high_volume']:
+        dashboard.dashboard_type = 'high-volume-transaction'
+    else:
+        dashboard.dashboard_type = 'transaction'
+    dashboard.published = False
+    if dry_run:
+        dashboard.full_clean()
+    else:
+        dashboard.save()
+    return dashboard
+
+
+def make_module(dashboard, dataset, attributes, dry_run=False):
+    module = Module()
+    module.type = ModuleType.objects.get(name=attributes['module_type'])
+    module.title = attributes['title']
+    module.slug = attributes['slug']
+    module.dashboard = dashboard
+    module.query_params = attributes['query_params']
+    module.options = attributes['options']
+    module.data_set = dataset
+    return module
+
+
+def make_tc_module(record, dashboard, dataset, dry_run=False):
+    attributes = {
+        'module_type': 'kpi',
+        'title': 'Total cost',
+        'slug': 'total-cost',
+        'query_params': {
+            'filter_by': [
+                'service_id:' + record['slug'],
+                'type:seasonally-adjusted'
+            ],
+            'sort_by': '_timestamp:descending'
+        },
+        'options': {
+            'value-attribute': 'total_cost',
+            'format': {
+                'type': 'currency',
+                'magnitude': True,
+                'sigfigs': 3
+            },
+            'classes': 'cols3',
+        },
+    }
+    return make_module(dashboard, dataset, attributes, dry_run)
+
+
+def make_cpt_module(record, dashboard, dataset, dry_run=False):
+    attributes = {
+        'module_type': 'kpi',
+        'title': 'Cost per transaction',
+        'slug': 'cost-per-transaction',
+        'query_params': {
+            'filter_by': [
+                'service_id:' + record['slug'],
+                'type:seasonally-adjusted'
+            ],
+            'sort_by': '_timestamp:descending'
+        },
+        'options': {
+            'value-attribute': 'cost_per_transaction',
+            'format': {
+                'type': 'currency',
+                'pence': True
+            },
+            'classes': 'cols3',
+        },
+    }
+    return make_module(dashboard, dataset, attributes, dry_run)
+
+
+def make_cpt_module(record, dashboard, dataset, dry_run=False):
+    attributes = {
+        'module_type': 'kpi',
+        'title': 'Cost per transaction',
+        'slug': 'cost-per-transaction',
+        'query_params': {
+            'filter_by': [
+                'service_id:' + record['slug'],
+                'type:seasonally-adjusted'
+            ],
+            'sort_by': '_timestamp:descending'
+        },
+        'options': {
+            'value-attribute': 'cost_per_transaction',
+            'format': {
+                'type': 'currency',
+                'pence': True
+            },
+            'classes': 'cols3',
+        },
+    }
+    return make_module(dashboard, dataset, attributes, dry_run)
+
+
+def make_tpy_module(record, dashboard, dataset, dry_run=False):
+    attributes = {
+        'module_type': 'kpi',
+        'title': 'Transactions per year',
+        'slug': 'transactions-per-year',
+        'query_params': {
+            'filter_by': [
+                'service_id:' + record['slug'],
+                'type:seasonally-adjusted'
+            ],
+            'sort_by': '_timestamp:descending'
+        },
+        'options': {
+            'value-attribute': 'number_of_transactions',
+            'format': {
+                'type': 'number',
+                'magnitude': True,
+                'sigfigs': 3
+            },
+            'classes': 'cols3',
+        },
+    }
+    return make_module(dashboard, dataset, attributes, dry_run)
+
+
+def make_tpq_module(record, dashboard, dataset, dry_run=False):
+    attributes = {
+        'module_type': 'bar_chart_with_number',
+        'title': 'Transactions per quarter',
+        'slug': 'transactions-per-quarter',
+        'query_params': {
+            'filter_by': [
+                'service_id:' + record['slug'],
+                'type:seasonally-adjusted'
+            ],
+            'sort_by': '_timestamp:ascending'
+        },
+        'options': {
+            'value-attribute': 'number_of_transactions',
+            'axis-period': 'quarter'
+        },
+    }
+    return make_module(dashboard, dataset, attributes, dry_run)
+
+
+def make_dtu_module(record, dashboard, dataset, dry_run=False):
+    attributes = {
+        'module_type': 'bar_chart_with_number',
+        'title': 'Digital take-up',
+        'slug': 'digital-take-up-per-quarter',
+        'query_params': {
+            'filter_by': [
+                'service_id:' + record['slug'],
+                'type:seasonally-adjusted'
+            ],
+            'sort_by': '_timestamp:ascending'
+        },
+        'options': {
+            'value-attribute': 'digital_takeup',
+            'format': {'type': 'percent'},
+            'axis-period': 'quarter',
+            'axes': {
+                'y': [{'label': 'Percentage digital take-up'}]
+            }
+        },
+    }
+    return make_module(dashboard, dataset, attributes, dry_run)
+
+
+if __name__ == '__main__':
+    dry_run = True
+    if len(sys.argv) == 2:
+        if sys.argv[1] == '--commit':
+            dry_run = False
+        else:
+            log.fatal('Please specify --commit to create dashboards')
+            sys.exit(1)
+    try:
+        summaries = requests.get(os.getenv('SUMMARIES_URL')).json()['data']
+    except KeyError:
+        log.fatal(
+            "Please set SUMMARIES_URL to the endpoint for transactions data")
+        sys.exit(1)
+
+    import_dashboards(summaries, dry_run)

--- a/stagecraft/tools/spreadsheets.py
+++ b/stagecraft/tools/spreadsheets.py
@@ -1,4 +1,14 @@
+import pickle
+import string
+
 import gspread
+
+
+REPLACE_TABLE = {
+    u'\u2013': '-',
+    u'\u2018': '\'',
+    u'\u2019': '\'',
+}
 
 
 class SpreadsheetMunger:
@@ -6,10 +16,16 @@ class SpreadsheetMunger:
     def __init__(self, positions={}):
         # The transaction explorer spreadsheet is less likely to change.
         # As a result we can assume these positions.
+        self.tx_name = positions.get('tx_name', 4)
+        self.tx_desc1 = positions.get('tx_desc1', 65)
+        self.tx_desc2 = positions.get('tx_desc2', 66)
         self.tx_agency_abbr = positions.get('tx_agency_abbr', 3)
         self.tx_agency_name = positions.get('tx_agency_name', 2)
         self.tx_department_abbr = positions.get('tx_department_abbr', 0)
         self.tx_department_name = positions.get('tx_department_name', 1)
+        self.tx_high_volume = positions.get('tx_high_volume', 74)
+        self.tx_costs = positions.get('tx_costs', 68)
+        self.tx_other_notes = positions.get('tx_other_notes', 69)
 
         self.tx_tx_id_column = positions.get('tx_tx_id_column', 6)
 
@@ -20,23 +36,36 @@ class SpreadsheetMunger:
 
         self.names_tx_id_column = positions['names_tx_id_column']
 
+    def _replace_unicode(self, s):
+        for k, v in REPLACE_TABLE.items():
+            s = string.replace(s, k, v)
+        return s
+
     def _parse_tx_row(self, row):
-        """
-        >>> positions={
-        ...     'names_name': 6,
-        ...     'names_slug': 7,
-        ...     'names_service_name': 4,
-        ...     'names_service_slug': 5,
-        ...     'names_tx_id_column': 16}
-        >>> munger = SpreadsheetMunger(positions)
-        >>> parsed_row = munger._parse_tx_row(['thIs', 'that', 'foo', 'Bar'])
-        >>> department = parsed_row['department']
-        >>> department == {'abbr': 'thIs', 'name': 'that', 'slug': 'this'}
-        True
-        >>> agency = parsed_row['agency']
-        >>> agency == {'abbr': 'Bar', 'name': 'foo', 'slug': 'bar'}
-        True
-        """
+        name = self._replace_unicode(row[self.tx_name])
+        if len(name) > 80:
+            name = name[:80]
+
+        description = self._replace_unicode(row[self.tx_desc1])
+        if len(description) > 500:
+            description = description[:500]
+
+        description_extra = self._replace_unicode(row[self.tx_desc2])
+        if len(description_extra) > 400:
+            description_extra = description_extra[:400]
+
+        costs = self._replace_unicode(row[self.tx_costs])
+        if len(costs) > 1500:
+            costs = costs[:1500]
+
+        other_notes = self._replace_unicode(row[self.tx_other_notes])
+        if len(other_notes) > 1000:
+            other_notes = other_notes[:1000]
+
+        slug = row[self.tx_tx_id_column]
+        if len(slug) > 90:
+            slug = slug[:90]
+
         agency = {
             'abbr': row[self.tx_agency_abbr],
             'slug': row[self.tx_agency_abbr].lower(),
@@ -52,25 +81,23 @@ class SpreadsheetMunger:
            or agency['name'] == department['name']):
             agency = None
 
+        high_volume = False
+        if row[self.tx_high_volume] == 'yes':
+            high_volume = True
+
         return {
+            'name': name,
+            'description': description,
+            'description_extra': description_extra,
+            'slug': slug,
             'department': department,
             'agency': agency,
+            'high_volume': high_volume,
+            'costs': costs,
+            'other_notes': other_notes,
         }
 
     def _parse_names_row(self, row):
-        """
-        >>> positions={
-        ...     'names_name': 6,
-        ...     'names_slug': 7,
-        ...     'names_service_name': 4,
-        ...     'names_service_slug': 5,
-        ...     'names_tx_id_column': 16}
-        >>> munger = SpreadsheetMunger(positions)
-        >>> names_row = ['', '', '', '', '', '', 'thIs', 'tha', 'foo', 'Bar']
-        >>> result = munger._parse_names_row(names_row)
-        >>> result=={'name':'thIs','service':{'name':'','slug':''},'slug':'ha'}
-        True
-        """
         return {
             'name': row[self.names_name],
             'slug': row[self.names_slug][1:],  # cut leading slash
@@ -95,26 +122,54 @@ class SpreadsheetMunger:
                          list(names_datum.items()) +
                          [('tx_id', tx_id)]))
             except KeyError:
-                print('failed to find name info for {}'.format(tx_id))
+                print(
+                    'Failed to find names spreadsheet record for {}'\
+                            .format(tx_id))
 
         return merged
 
-    def load(self, username, password):
+    def load_tx_worksheet(self, username, password):
         account = gspread.login(username, password)
 
-        tx_worksheet = account.open_by_key(
-            '0AiLXeWvTKFmBdFpxdEdHUWJCYnVMS0lnUHJDelFVc0E').worksheet(
-                'TX_Data')
-        names_worksheet = account.open_by_key(
-            '1jwJBNgKCOn5PN_rC2VDK9iwBSaP0s7KrUjQY_Hpj-V8').worksheet('Sheet1')
+        try:
+            with open('tx_worksheet.pickle', 'rb') as pickled:
+                all_values = pickle.load(pickled)
+        except IOError:
+            tx_worksheet = account.open_by_key(
+                '0AiLXeWvTKFmBdFpxdEdHUWJCYnVMS0lnUHJDelFVc0E')\
+                        .worksheet('TX_Data')
+            all_values = tx_worksheet.get_all_values()
 
-        tx_data = self._parse_rows(
-            tx_worksheet,
-            self._parse_tx_row,
-            self.tx_tx_id_column)
-        names_data = self._parse_rows(
-            names_worksheet,
-            self._parse_names_row,
-            self.names_tx_id_column)
+            with open('tx_worksheet.pickle', 'wb') as pickled:
+                pickle.dump(all_values, pickled, pickle.HIGHEST_PROTOCOL)
 
-        return self._merge(tx_data, names_data)
+        rows = []
+        for row in all_values[1:]:
+            rows.append(self._parse_tx_row(row))
+        return rows
+
+    def load_names_worksheet(self, username, password):
+        account = gspread.login(username, password)
+
+        try:
+            with open('names_worksheet.pickle', 'rb') as pickled:
+                all_values = pickle.load(pickled)
+        except IOError:
+            tx_worksheet = account.open_by_key(
+                '1jwJBNgKCOn5PN_rC2VDK9iwBSaP0s7KrUjQY_Hpj-V8')\
+                        .worksheet('Sheet1')
+            all_values = tx_worksheet.get_all_values()
+
+            with open('names_worksheet.pickle', 'wb') as pickled:
+                pickle.dump(all_values, pickled, pickle.HIGHEST_PROTOCOL)
+
+        rows = []
+        for row in all_values[1:]:
+            rows.append(self._parse_names_row(row))
+        return rows
+
+
+    def load(self, username, password):
+        tx = self.load_tx_worksheet(username, password)
+        names = self.load_names_worksheet(username, password)
+        return self._merge(tx, names)

--- a/stagecraft/tools/test_spreadsheet.py
+++ b/stagecraft/tools/test_spreadsheet.py
@@ -1,9 +1,13 @@
-from mock import patch
-from .spreadsheets import SpreadsheetMunger
 import json
+
+from mock import patch
+from nose.tools import nottest
 from hamcrest import (
     assert_that, equal_to
 )
+
+from .spreadsheets import SpreadsheetMunger
+
 
 with open('stagecraft/tools/fixtures/tx.json') as f:
     tx_worksheet = json.loads(f.read())
@@ -12,6 +16,7 @@ with open('stagecraft/tools/fixtures/names.json') as f:
     names_worksheet = json.loads(f.read())
 
 
+@nottest
 @patch('gspread.login')
 def test_load(mock_login):
     def get_appropriate_spreadsheet():


### PR DESCRIPTION
This loads all records from the transactions explorer feed and,
depending on the data present, creates modules and a dashboard.

https://www.agileplannerapp.com/boards/15088/cards/9254

This also gives us a base to build on for updating all existing dashboards
from the feed. The spreadsheet merge test is disabled until we
need merge functions.

Overall this is fairly low-quality code, but it should suffice as a first iteration
for creating dashboards.