### PR TITLE
fix / more diagnostics for slow dashboard endpoint

### DIFF
--- a/requirements/_common.txt
+++ b/requirements/_common.txt
@@ -24,3 +24,4 @@ django-statsd-mozilla==0.3.12
 
 #for pulling transactions explorer spreadsheets.
 gspread==0.2.2
+dogslow==0.9.7

--- a/stagecraft/apps/dashboards/models/module.py
+++ b/stagecraft/apps/dashboards/models/module.py
@@ -14,6 +14,13 @@ from stagecraft.apps.datasets.models import DataSet
 
 from .dashboard import Dashboard
 
+class ModuleManager(models.Manager):
+
+    def get_queryset(self):
+        return super(ModuleManager, self).get_queryset().select_related(
+            'data_set__data_group', 'data_set__data_type',
+            'type')
+
 
 class ModuleType(models.Model):
     id = UUIDField(auto=True, primary_key=True, hyphenate=True)
@@ -75,6 +82,8 @@ class Module(models.Model):
     query_parameters = JSONField(null=True, blank=True)
 
     order = models.IntegerField()
+
+    objects = ModuleManager()
 
     # should run on normal validate
     def validate_options(self):

--- a/stagecraft/apps/dashboards/views/dashboard.py
+++ b/stagecraft/apps/dashboards/views/dashboard.py
@@ -21,6 +21,7 @@ from stagecraft.libs.views.utils import to_json, create_error
 from stagecraft.libs.views.transaction import atomic_view
 from .module import add_module_to_dashboard
 from ..models.module import Module
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -42,10 +43,20 @@ def dashboard_list_for_spotlight():
 
 
 def single_dashboard_for_spotlight(request, dashboard_slug):
+    start = time.time()
+    logger.info('fetching dashboard')
     dashboard = fetch_dashboard(dashboard_slug)
+    fetch_time = time.time()
+    fetch_elapsed = fetch_time - start
+    logger.info('fetching dashboard took {}'.format(
+        fetch_elapsed), extra={'elapsed_time': fetch_elapsed})
     if not dashboard:
         return error_response(request, dashboard_slug)
     dashboard_json = dashboard.spotlightify(dashboard_slug)
+    spotlightify_time = time.time()
+    spotlightify_elapsed = spotlightify_time - start
+    logger.info('spotlightifying dashboard took {}'.format(
+        spotlightify_elapsed), extra={'elapsed_time': spotlightify_elapsed})
     if not dashboard_json:
         return error_response(request, dashboard_slug)
     json_str = to_json(dashboard_json)

--- a/stagecraft/settings/common.py
+++ b/stagecraft/settings/common.py
@@ -74,6 +74,7 @@ INSTALLED_APPS = (
 )
 
 MIDDLEWARE_CLASSES = (
+    'dogslow.WatchdogMiddleware',
     'django_statsd.middleware.GraphiteRequestTimingMiddleware',
     'stagecraft.libs.request_logger.middleware.RequestLoggerMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -115,3 +116,8 @@ NOSE_ARGS = ['-s', '--exclude-dir=stagecraft/settings']
 
 STATIC_URL = '/static/'
 STATIC_ROOT = abspath(pjoin(BASE_DIR, 'assets'))
+
+DOGSLOW_LOG_TO_FILE = False
+DOGSLOW_TIMER = 1
+DOGSLOW_LOGGER = 'stagecraft.apps'
+DOGSLOW_LOG_LEVEL = 'INFO'


### PR DESCRIPTION
We have noticed a number of requests resulting in a 502 error because stagecraft
is timed out by gunicorn. This is usually requesting the config for an individual
dashboard. Profiling this endpoint showed a lot of queries being generated - the
change to the module manager reduces this significantly. This also adds some 
timings to that endpoint, and uses dogslow to give a stack trace of a slow request