### PR TITLE
Add gc stats

### DIFF
--- a/stagecraft/wsgi.py
+++ b/stagecraft/wsgi.py
@@ -16,7 +16,7 @@ import gc
 import logging
 import sys
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('gunicorn.error')
 
 
 class writer(object):

--- a/stagecraft/wsgi.py
+++ b/stagecraft/wsgi.py
@@ -13,5 +13,16 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE",
 
 from django.core.wsgi import get_wsgi_application
 import gc
+import logging
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+class writer(object):
+    def write(self, data):
+        logger.info(data)
+
+sys.stderr = writer()
 gc.set_debug(gc.DEBUG_STATS)
 application = get_wsgi_application()

--- a/stagecraft/wsgi.py
+++ b/stagecraft/wsgi.py
@@ -12,4 +12,6 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE",
                       "stagecraft.settings.production")
 
 from django.core.wsgi import get_wsgi_application
+import gc
+gc.set_debug(gc.DEBUG_STATS)
 application = get_wsgi_application()


### PR DESCRIPTION
The stats will be written to the gunicorn error file, which makes it easy to 
check when processes have been killed.