### PR TITLE
Add some more timing information to stagecraft

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
   postgresql: "9.3"
 env:
   matrix:
-    - DJANGO_SETTINGS_MODULE=stagecraft.settings.ci SECRET_KEY=xyz DATABASE_URL=postgres://postgres:@localhost:5432/stagecraft
+    - DJANGO_SETTINGS_MODULE=stagecraft.settings.ci SECRET_KEY=xyz DATABASE_URL=postgres://postgres:@localhost:5432/stagecraft NO_AUTOPEP8=1
   global:
     # NOTE: contains GH_TOKEN=xxx from github user gds-pp-ci
     secure: AnhgvS32/AMPi8rl9L9xh/2Xmt1459jXs13eiJI4kHtSGP/n2gkZtfKTiU9wezNqI5tVk4fYYltJNjvk5ZGkiEm/z5vpp8urRHUcGejZaa6ziyzFALpftuI5/5TF/dnlowQdFjh4Tcx4crZ1u5l4z5eJoxUSd4x9hk4d8/Tnjj8=

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -43,7 +43,7 @@ find $basedir/stagecraft -iname '__pycache__' -exec rmdir {} \+
 pip install -r requirements/ci.txt --use-mirrors
 
 if [ -z "$NO_AUTOPEP8" ]; then
-  autopep8 -i -r stagecraft
+  autopep8 -i -r stagecraft --exclude '00*.py'
 fi
 
 # run style check

--- a/stagecraft/apps/dashboards/models/module.py
+++ b/stagecraft/apps/dashboards/models/module.py
@@ -14,6 +14,7 @@ from stagecraft.apps.datasets.models import DataSet
 
 from .dashboard import Dashboard
 
+
 class ModuleManager(models.Manager):
 
     def get_queryset(self):

--- a/stagecraft/apps/transforms/admin.py
+++ b/stagecraft/apps/transforms/admin.py
@@ -8,7 +8,8 @@ class TransformTypeAdmin(admin.ModelAdmin):
 
 
 class TransformAdmin(admin.ModelAdmin):
-    list_display = ('input_group', 'input_type', 'output_group', 'output_type',)
+    list_display = (
+        'input_group', 'input_type', 'output_group', 'output_type',)
 
 
 admin.site.register(TransformType, TransformTypeAdmin)

--- a/stagecraft/libs/timing/timer.py
+++ b/stagecraft/libs/timing/timer.py
@@ -1,0 +1,21 @@
+import time
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def timeit(method):
+
+    def timed(*args, **kw):
+        ts = time.time()
+        logger.info('{!r} starting'.format(method.__name__))
+        result = method(*args, **kw)
+        te = time.time()
+        elapsed = te - ts
+        logger.info(
+            '{!r} took {:.2f}'.format(
+                method.__name__, elapsed),
+            extra={'elapsed_time': elapsed, 'method_args': args, 'kw': kw})
+        return result
+
+    return timed

--- a/stagecraft/tools/import_dashboards.py
+++ b/stagecraft/tools/import_dashboards.py
@@ -88,8 +88,8 @@ def set_dashboard_attributes(dashboard, record, dry_run, publish):
             dashboard.organisation = org
         except Node.DoesNotExist:
             if not dry_run:
-                log.warn('Organisation not found for record : {}' \
-                    .format(record['tx_id']))
+                log.warn('Organisation not found for record : {}'
+                         .format(record['tx_id']))
 
     if record['high_volume']:
         dashboard.dashboard_type = 'high-volume-transaction'
@@ -126,7 +126,6 @@ def import_dashboard(record, summaries, dry_run=True, publish=False):
 
 
 def determine_modules_for_dashboard(summaries, tx_id):
-
     """
     Inspect the summary data for a given tx_id and determine
     whether modules should be created for the different data types.
@@ -318,8 +317,8 @@ def import_tpy_module(record, dashboard, dataset):
                 'sigfigs': 3
             },
             'classes': 'cols3',
-            },
-        }
+        },
+    }
     module = get_or_create_module(dashboard, attributes['slug'])
     return set_module_attributes(module, dashboard, dataset, attributes)
 

--- a/stagecraft/tools/redirects.py
+++ b/stagecraft/tools/redirects.py
@@ -73,7 +73,7 @@ if __name__ == '__main__':
         password = os.environ['GOOGLE_PASSWORD']
     except KeyError:
         print("Please supply username (GOOGLE_USERNAME)"
-            "and password (GOOGLE_PASSWORD) as environment variables")
+              "and password (GOOGLE_PASSWORD) as environment variables")
         sys.exit(1)
 
     munger = SpreadsheetMunger({

--- a/stagecraft/tools/spreadsheets.py
+++ b/stagecraft/tools/spreadsheets.py
@@ -196,7 +196,8 @@ class SpreadsheetMunger:
             record['description'] = description
 
         if record.get('description_extra'):
-            description_extra = self._replace_unicode(record['description_extra'])
+            description_extra = self._replace_unicode(
+                record['description_extra'])
             if len(description_extra) > 400:
                 description_extra = description_extra[:400]
             record['description_extra'] = description_extra

--- a/stagecraft/tools/test_import_dashboards.py
+++ b/stagecraft/tools/test_import_dashboards.py
@@ -3,13 +3,13 @@ import json
 from mock import patch, Mock
 from hamcrest import (
     assert_that, has_properties, has_entries
-    )
+)
 
 from stagecraft.apps.dashboards.models import Dashboard
 
 from .spreadsheets import SpreadsheetMunger
 from .import_dashboards import (set_dashboard_attributes,
-    determine_modules_for_dashboard)
+                                determine_modules_for_dashboard)
 
 with open('stagecraft/tools/fixtures/tx.json') as f:
     tx_worksheet = json.loads(f.read())
@@ -171,7 +171,7 @@ def test_digital_takeup_present_quarterly():
             'service_id': 'tx_id',
             'type': 'quarterly',
             'digital_takeup': 240542,
-            }
+        }
     ]
     module_types = determine_modules_for_dashboard(summaries, 'tx_id')
 
@@ -179,7 +179,7 @@ def test_digital_takeup_present_quarterly():
         'transactions_per_year': True,
         'transactions_per_quarter': True,
         'digital_takeup': True,
-        }))
+    }))
 
 
 def test_total_cost_present():

--- a/stagecraft/tools/test_redirect_generation.py
+++ b/stagecraft/tools/test_redirect_generation.py
@@ -31,6 +31,7 @@ def ordered_responses(spotlight_code):
 
 
 class RedirectWriterTests(unittest.TestCase):
+
     @patch('requests.get')
     def test_redirects_produced_when_source_pages_exist(self, mock_get):
         mock_get().status_code = 200

--- a/stagecraft/tools/tests/test_spreadsheet.py
+++ b/stagecraft/tools/tests/test_spreadsheet.py
@@ -28,15 +28,16 @@ def test_merge():
     })
 
     mock_account = Mock()
-    mock_account.open_by_key().worksheet().get_all_values.return_value = tx_worksheet
+    mock_account.open_by_key().worksheet(
+    ).get_all_values.return_value = tx_worksheet
     tx = munger.load_tx_worksheet(mock_account)
 
     mock_account = Mock()
-    mock_account.open_by_key().worksheet().get_all_values.return_value = names_worksheet
+    mock_account.open_by_key().worksheet(
+    ).get_all_values.return_value = names_worksheet
     names = munger.load_names_worksheet(mock_account)
 
     result = munger.merge(tx, names)
     result_path = 'stagecraft/tools/fixtures/spreadsheet_munging_result.json'
     with open(result_path, 'r') as f:
         assert_that(result[0], has_entries(json.loads(f.read())[0]))
-

--- a/stagecraft/wsgi.py
+++ b/stagecraft/wsgi.py
@@ -20,6 +20,7 @@ logger = logging.getLogger('gunicorn.error')
 
 
 class writer(object):
+
     def write(self, data):
         logger.info(data)
 


### PR DESCRIPTION
To help with tracking down the 502 errors on production - some seem to be
hanging during the spotlightify stage. Use a decorator to do the timings

Also stop running autopep8 in travis, dont run it on autogenerated migrations
and fix the pep8 errors