### PR TITLE
Add a request-id to all log messages

### DIFF
--- a/stagecraft/libs/request_logger/middleware.py
+++ b/stagecraft/libs/request_logger/middleware.py
@@ -5,12 +5,23 @@ from __future__ import unicode_literals
 import logging
 import time
 
+from threading import local
+
+
 logger = logging.getLogger(__name__)
+
+_thread_locals = local()
+
+
+def get_current_request():
+    """ returns the request object for this thead """
+    return getattr(_thread_locals, "request", None)
 
 
 class RequestLoggerMiddleware(object):
 
     def process_request(self, request):
+        _thread_locals.request = request
         request.start_request_time = time.time()
         logger.info("{method} {path}".format(
             method=request.method,
@@ -38,3 +49,15 @@ class RequestLoggerMiddleware(object):
                     'request_time': elapsed_time,
             })
         return response
+
+
+class AdditionalFieldsFilter(logging.Filter):
+
+    def filter(self, record):
+        request = get_current_request()
+        if request:
+            record.__dict__['request_method'] = request.method,
+            record.__dict__['http_host'] = request.META.get('HTTP_HOST'),
+            record.__dict__['http_path'] = request.get_full_path(),
+            record.__dict__['request_id'] = request.META.get('HTTP_REQUEST_ID')
+        return 1

--- a/stagecraft/settings/development.py
+++ b/stagecraft/settings/development.py
@@ -113,6 +113,11 @@ LOGGING = {
             'fmt': '{"extra": {"@tags": ["application", "stagecraft"]}}',
         },
     },
+    'filters': {
+        'additional_fields': {
+            '()': 'stagecraft.libs.request_logger.middleware.AdditionalFieldsFilter',  # noqa
+        }
+    },
     'handlers': {
         'null': {
             'level': 'DEBUG',
@@ -141,6 +146,7 @@ LOGGING = {
             'maxBytes': 4 * 1024 * 1024,
             'backupCount': 2,
             'formatter': 'logstash_json',
+            'filters': ['additional_fields'],
         },
         'console': {
             'level': 'INFO',

--- a/stagecraft/settings/production.py
+++ b/stagecraft/settings/production.py
@@ -35,6 +35,11 @@ LOGGING = {
             'fmt': '{"extra": {"@tags": ["application", "stagecraft"]}}',
         },
     },
+    'filters': {
+        'additional_fields': {
+            '()': 'stagecraft.libs.request_logger.middleware.AdditionalFieldsFilter',  # noqa
+        }
+    },
     'handlers': {
         'null': {
             'level': 'INFO',
@@ -47,6 +52,7 @@ LOGGING = {
             'maxBytes': 4 * 1024 * 1024,
             'backupCount': 2,
             'formatter': 'standard',
+            'filters': ['additional_fields'],
         },
         'json_log': {
             'level': 'DEBUG',


### PR DESCRIPTION
For tracing the 502 errors we are seeing.

From kibana, we can trace an nginx 502 with a request-id to a single log
line in stagecraft, which is when the request processing is started.
From here we can get a process_id, but it is impossible to work out
which log lines refer to the same request as a process can handle
multiple requests.

This uses the idea in
https://raw.githubusercontent.com/jedie/django-tools/master/django_tools/middlewares/ThreadLocal.py
to store the request in a thread local variable, which we can then
reference when logging