### PR TITLE
Improve organisation and dashboard loading/querying

### DIFF
--- a/stagecraft/apps/dashboards/migrations/0011_auto__add_field_dashboard_department_cache__add_field_dashboard_agency.py
+++ b/stagecraft/apps/dashboards/migrations/0011_auto__add_field_dashboard_department_cache__add_field_dashboard_agency.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Dashboard.department_cache'
+        db.add_column(u'dashboards_dashboard', 'department_cache',
+                      self.gf('django.db.models.fields.related.ForeignKey')(blank=True, related_name='dashboards_owned_by_department', null=True, to=orm['organisation.Node']),
+                      keep_default=False)
+
+        # Adding field 'Dashboard.agency_cache'
+        db.add_column(u'dashboards_dashboard', 'agency_cache',
+                      self.gf('django.db.models.fields.related.ForeignKey')(blank=True, related_name='dashboards_owned_by_agency', null=True, to=orm['organisation.Node']),
+                      keep_default=False)
+
+        # Adding field 'Dashboard.service_cache'
+        db.add_column(u'dashboards_dashboard', 'service_cache',
+                      self.gf('django.db.models.fields.related.ForeignKey')(blank=True, related_name='dashboards_owned_by_service', null=True, to=orm['organisation.Node']),
+                      keep_default=False)
+
+        # Adding field 'Dashboard.transaction_cache'
+        db.add_column(u'dashboards_dashboard', 'transaction_cache',
+                      self.gf('django.db.models.fields.related.ForeignKey')(blank=True, related_name='dashboards_owned_by_transaction', null=True, to=orm['organisation.Node']),
+                      keep_default=False)
+
+        # Changing field 'Dashboard.title'
+        db.alter_column(u'dashboards_dashboard', 'title', self.gf('django.db.models.fields.CharField')(max_length=256))
+
+    def backwards(self, orm):
+        # Deleting field 'Dashboard.department_cache'
+        db.delete_column(u'dashboards_dashboard', 'department_cache_id')
+
+        # Deleting field 'Dashboard.agency_cache'
+        db.delete_column(u'dashboards_dashboard', 'agency_cache_id')
+
+        # Deleting field 'Dashboard.service_cache'
+        db.delete_column(u'dashboards_dashboard', 'service_cache_id')
+
+        # Deleting field 'Dashboard.transaction_cache'
+        db.delete_column(u'dashboards_dashboard', 'transaction_cache_id')
+
+        # Changing field 'Dashboard.title'
+        db.alter_column(u'dashboards_dashboard', 'title', self.gf('django.db.models.fields.CharField')(max_length=80))
+
+    models = {
+        'dashboards.dashboard': {
+            'Meta': {'object_name': 'Dashboard'},
+            'agency_cache': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'dashboards_owned_by_agency'", 'null': 'True', 'to': u"orm['organisation.Node']"}),
+            'business_model': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '31', 'blank': 'True'}),
+            'costs': ('django.db.models.fields.CharField', [], {'max_length': '1500', 'blank': 'True'}),
+            'customer_type': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '20', 'blank': 'True'}),
+            'dashboard_type': ('django.db.models.fields.CharField', [], {'default': "'transaction'", 'max_length': '30'}),
+            'department_cache': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'dashboards_owned_by_department'", 'null': 'True', 'to': u"orm['organisation.Node']"}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'description_extra': ('django.db.models.fields.CharField', [], {'max_length': '400', 'blank': 'True'}),
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'improve_dashboard_message': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'organisation': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Node']", 'null': 'True', 'blank': 'True'}),
+            'other_notes': ('django.db.models.fields.CharField', [], {'max_length': '1000', 'blank': 'True'}),
+            'page_type': ('django.db.models.fields.CharField', [], {'default': "'dashboard'", 'max_length': '80'}),
+            'published': ('django.db.models.fields.BooleanField', [], {}),
+            'service_cache': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'dashboards_owned_by_service'", 'null': 'True', 'to': u"orm['organisation.Node']"}),
+            'slug': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '90'}),
+            'strapline': ('django.db.models.fields.CharField', [], {'default': "'Dashboard'", 'max_length': '40'}),
+            'tagline': ('django.db.models.fields.CharField', [], {'max_length': '400', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'transaction_cache': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'dashboards_owned_by_transaction'", 'null': 'True', 'to': u"orm['organisation.Node']"})
+        },
+        'dashboards.link': {
+            'Meta': {'object_name': 'Link'},
+            'dashboard': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dashboards.Dashboard']"}),
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'link_type': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        'dashboards.module': {
+            'Meta': {'unique_together': "(('dashboard', 'slug'),)", 'object_name': 'Module'},
+            'dashboard': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dashboards.Dashboard']"}),
+            'data_set': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['datasets.DataSet']", 'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'info': ('dbarray.fields.TextArrayField', [], {'blank': 'True'}),
+            'options': ('jsonfield.fields.JSONField', [], {'blank': 'True'}),
+            'order': ('django.db.models.fields.IntegerField', [], {}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dashboards.Module']", 'null': 'True', 'blank': 'True'}),
+            'query_parameters': ('jsonfield.fields.JSONField', [], {'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '60'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '60'}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dashboards.ModuleType']"})
+        },
+        'dashboards.moduletype': {
+            'Meta': {'object_name': 'ModuleType'},
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '25'}),
+            'schema': ('jsonfield.fields.JSONField', [], {})
+        },
+        u'datasets.datagroup': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'DataGroup'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '60'})
+        },
+        u'datasets.dataset': {
+            'Meta': {'ordering': "[u'name']", 'unique_together': "([u'data_group', u'data_type'],)", 'object_name': 'DataSet'},
+            'auto_ids': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'bearer_token': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'capped_size': ('django.db.models.fields.PositiveIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'data_group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['datasets.DataGroup']", 'on_delete': 'models.PROTECT'}),
+            'data_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['datasets.DataType']", 'on_delete': 'models.PROTECT'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'max_age_expected': ('django.db.models.fields.PositiveIntegerField', [], {'default': '86400', 'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '200', 'blank': 'True'}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'queryable': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'raw_queries_allowed': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'realtime': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'upload_filters': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'upload_format': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        u'datasets.datatype': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'DataType'},
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '60'})
+        },
+        u'organisation.node': {
+            'Meta': {'object_name': 'Node'},
+            'abbreviation': ('django.db.models.fields.CharField', [], {'max_length': '50', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '256'}),
+            'parents': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['organisation.Node']", 'symmetrical': 'False'}),
+            'slug': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '90'}),
+            'typeOf': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.NodeType']"})
+        },
+        u'organisation.nodetype': {
+            'Meta': {'object_name': 'NodeType'},
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '256'})
+        }
+    }
+
+    complete_apps = ['dashboards']

--- a/stagecraft/apps/dashboards/tests/models/test_dashboard.py
+++ b/stagecraft/apps/dashboards/tests/models/test_dashboard.py
@@ -23,13 +23,16 @@ class DashboardTestCase(TransactionTestCase):
 
     def test_class_level_list_for_spotlight_returns_minimal_json_array(self):
         dashboard_two = DashboardFactory()
-        dashboard_two.organisation = AgencyWithDepartmentFactory()
+        organisation = AgencyWithDepartmentFactory()
+        dashboard_two.organisation = organisation
+        dashboard_two.department_cache = organisation.parents.first()
+        dashboard_two.agency_cache = organisation
         dashboard_two.validate_and_save()
         DashboardFactory(published=False)
         list_for_spotlight = Dashboard.list_for_spotlight()
         assert_that(list_for_spotlight['page-type'], equal_to('browse'))
         assert_that(len(list_for_spotlight['items']), equal_to(2))
-        assert_that(list_for_spotlight['items'][1],
+        assert_that(list_for_spotlight['items'][0],
                     has_entries({
                         'slug': starts_with('slug'),
                         'title': 'title',
@@ -43,7 +46,7 @@ class DashboardTestCase(TransactionTestCase):
                             'abbr': starts_with('abbreviation')
                         })
                     }))
-        assert_that(list_for_spotlight['items'][0],
+        assert_that(list_for_spotlight['items'][1],
                     has_entries({
                         'slug': starts_with('slug'),
                         'title': 'title',

--- a/stagecraft/apps/organisation/views.py
+++ b/stagecraft/apps/organisation/views.py
@@ -126,6 +126,7 @@ class NodeView(ResourceView):
             'id': str(model.id),
             'type': NodeTypeView.serialize(model.typeOf),
             'name': model.name,
+            'slug': model.slug,
         }
 
         if model.abbreviation is not None:

--- a/stagecraft/tools/import_dashboards.py
+++ b/stagecraft/tools/import_dashboards.py
@@ -1,11 +1,11 @@
 import argparse
-import logging
 import os
 import sys
 
 import requests
 
 from django.db import IntegrityError
+from django.db.utils import DataError
 from django.core.exceptions import ValidationError
 
 from .spreadsheets import SpreadsheetMunger
@@ -13,15 +13,7 @@ from .spreadsheets import SpreadsheetMunger
 from stagecraft.apps.dashboards.models import Dashboard
 from stagecraft.apps.dashboards.models import Module
 from stagecraft.apps.dashboards.models import ModuleType
-from stagecraft.apps.organisation.models import Node
 from stagecraft.apps.datasets.models import DataSet
-
-
-log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler()
-handler.setLevel(logging.DEBUG)
-log.addHandler(handler)
 
 
 def import_dashboards(summaries, update_all=False,
@@ -30,7 +22,7 @@ def import_dashboards(summaries, update_all=False,
         username = os.environ['GOOGLE_USERNAME']
         password = os.environ['GOOGLE_PASSWORD']
     except KeyError:
-        log.fatal("Please supply username (GOOGLE_USERNAME)\
+        print("Please supply username (GOOGLE_USERNAME)\
                 and password (GOOGLE_PASSWORD) as environment variables")
         sys.exit(1)
 
@@ -45,7 +37,7 @@ def import_dashboards(summaries, update_all=False,
         'names_tx_id': 19,
     })
     records = loader.load(username, password)
-    log.debug('Loaded {} records'.format(len(records)))
+    print('Loaded {} records'.format(len(records)))
 
     failed_dashboards = []
     for record in records:
@@ -53,13 +45,15 @@ def import_dashboards(summaries, update_all=False,
             loader.sanitise_record(record)
             try:
                 import_dashboard(record, summaries, dry_run, publish)
-            except ValidationError:
-                failed_dashboards.append(record)
+            except (DataError, ValidationError) as e:
+                print(e)
+                failed_dashboards.append(record['tx_id'])
 
-    log.error('Failed dashboards: {}'.format(failed_dashboards))
+    if failed_dashboards:
+        print('Failed dashboards: {}'.format(failed_dashboards))
 
 
-def set_dashboard_attributes(dashboard, record, dry_run, publish):
+def set_dashboard_attributes(dashboard, record, publish):
 
     dashboard.title = record['name']
     # Only set slug on new dashboards
@@ -77,24 +71,8 @@ def set_dashboard_attributes(dashboard, record, dry_run, publish):
         dashboard.customer_type = record['customer_type']
     if record.get('business_model'):
         dashboard.business_model = record['business_model']
-
-    if dashboard.organisation is None:
-        if record.get('agency'):
-            key = 'agency'
-        else:
-            key = 'department'
-        try:
-            org = Node.objects.get(abbreviation=record[key]['abbr'])
-            dashboard.organisation = org
-        except Node.DoesNotExist:
-            if not dry_run:
-                log.warn('Organisation not found for record : {}'
-                         .format(record['tx_id']))
-
-    if record['high_volume']:
-        dashboard.dashboard_type = 'high-volume-transaction'
-    else:
-        dashboard.dashboard_type = 'transaction'
+    # Set type to high volume to distinguish from manually built dashboards.
+    dashboard.dashboard_type = 'high-volume-transaction'
 
     if publish:
         dashboard.published = True
@@ -107,15 +85,12 @@ def set_dashboard_attributes(dashboard, record, dry_run, publish):
 
 def import_dashboard(record, summaries, dry_run=True, publish=False):
 
-    log.debug(record)
     try:
         dashboard = Dashboard.objects.get(slug=record['tx_id'])
-        log.debug('Retrieved dashboard: {}'.format(record['tx_id']))
     except Dashboard.DoesNotExist:
         dashboard = Dashboard()
-        log.debug('Creating dashboard: {}'.format(record['tx_id']))
 
-    dashboard = set_dashboard_attributes(dashboard, record, dry_run, publish)
+    dashboard = set_dashboard_attributes(dashboard, record, publish)
     if dry_run:
         dashboard.full_clean()
     else:
@@ -190,10 +165,8 @@ def import_modules(dashboard, dataset, record, summaries):
         if not dry_run:
             try:
                 module.save()
-                log.debug('Added module: {}'.format(module.slug))
             except IntegrityError as e:
-                log.error(
-                    'Error saving module {}: {}'.format(module.slug, str(e)))
+                print('Error saving module {}: {}'.format(module.slug, str(e)))
 
 
 def get_dataset():
@@ -331,7 +304,7 @@ def import_tpq_module(record, dashboard, dataset):
         'query_params': {
             'filter_by': [
                 'service_id:' + record['tx_id'],
-                'type:seasonally-adjusted'
+                'type:quarterly'
             ],
             'sort_by': '_timestamp:ascending'
         },
@@ -352,7 +325,7 @@ def import_dtu_module(record, dashboard, dataset):
         'query_params': {
             'filter_by': [
                 'service_id:' + record['tx_id'],
-                'type:seasonally-adjusted'
+                'type:quarterly'
             ],
             'sort_by': '_timestamp:ascending'
         },
@@ -382,17 +355,17 @@ if __name__ == '__main__':
                         action="store_true")
     args = parser.parse_args()
     if args.all:
-        log.info("Updating all dashboards")
+        print("Updating all dashboards")
         update_all = True
     else:
         update_all = False
     if args.commit:
-        log.info("Committing changes")
+        print("Committing changes")
         dry_run = False
     else:
         dry_run = True
     if args.publish:
-        log.info("Publishing all dashboards")
+        print("Publishing all dashboards")
         publish = True
     else:
         publish = False
@@ -400,8 +373,7 @@ if __name__ == '__main__':
     if os.getenv('SUMMARIES_URL'):
         summaries = requests.get(os.getenv('SUMMARIES_URL')).json()['data']
     else:
-        log.fatal(
-            "Please set SUMMARIES_URL to the endpoint for transactions data")
+        print("Please set SUMMARIES_URL to the endpoint for transactions data")
         sys.exit(1)
 
     import_dashboards(summaries, update_all, dry_run, publish)

--- a/stagecraft/tools/spreadsheets.py
+++ b/stagecraft/tools/spreadsheets.py
@@ -1,15 +1,7 @@
-import logging
 import pickle
 import string
 
 import gspread
-
-
-log = logging.getLogger(__name__)
-log.setLevel(logging.ERROR)
-handler = logging.StreamHandler()
-handler.setLevel(logging.ERROR)
-log.addHandler(handler)
 
 
 REPLACE_TABLE = {
@@ -98,21 +90,26 @@ class SpreadsheetMunger:
         record = {}
         record['tx_id'] = row[self.names_tx_id]
 
-        if row[self.names_transaction_name]:
+        # If a record does not have a transaction, the service name/slug is
+        # used.
+        if row[self.names_transaction_name] and \
+                row[self.names_transaction_slug]:
             record['name'] = row[self.names_transaction_name]
-        elif row[self.names_service_name]:
-            record['name'] = row[self.names_service_name]
-        else:
-            log.error('Missing name for {}'.format(row[self.names_tx_id]))
-            return None
-
-        if row[self.names_transaction_slug]:
             record['slug'] = row[self.names_transaction_slug][1:]
-        elif row[self.names_service_slug]:
-            record['slug'] = row[self.names_service_slug]
-        else:
-            log.error('Missing slug for {}'.format(row[self.names_tx_id]))
-            return None
+            record['transaction'] = {
+                'name': row[self.names_transaction_name],
+                'slug': row[self.names_transaction_slug][1:],
+            }
+
+        if row[self.names_service_name] and \
+                row[self.names_service_slug]:
+            record['service'] = {
+                'name': row[self.names_service_name],
+                'slug': row[self.names_service_slug][1:]
+            }
+            if not record.get('name'):
+                record['name'] = row[self.names_service_name]
+                record['slug'] = row[self.names_service_slug][1:]
 
         if row[self.names_description]:
             record['description'] = row[self.names_description]
@@ -121,18 +118,7 @@ class SpreadsheetMunger:
             record['costs'] = row[self.names_notes]
         if row[self.names_other_notes]:
             record['other_notes'] = row[self.names_other_notes]
-        if row[self.names_service_name] and \
-                row[self.names_service_slug]:
-            record['service'] = {
-                'name': row[self.names_service_name],
-                'slug': row[self.names_service_slug][1:]
-            }
-        if row[self.names_transaction_name] and \
-                row[self.names_transaction_slug]:
-            record['transaction'] = {
-                'name': row[self.names_transaction_name],
-                'slug': row[self.names_transaction_slug][1:],
-            }
+
         return record
 
     def _parse_rows(self, worksheet, parse_fn, tx_id_column):
@@ -154,7 +140,9 @@ class SpreadsheetMunger:
             .worksheet('Sheet1').get_all_values()
         rows = []
         for row in all_values[1:]:
-            rows.append(self._parse_names_row(row))
+            parsed = self._parse_names_row(row)
+            if parsed is not None:
+                rows.append(parsed)
         return rows
 
     def merge(self, tx, names):
@@ -178,15 +166,17 @@ class SpreadsheetMunger:
             except KeyError:
                 unmerged.append(tx_id)
         if unmerged:
-            log.error("There were unmerged records: {}".format(unmerged))
+            print("There were unmerged records:")
+            for record in unmerged:
+                print(record)
         return merged
 
     def sanitise_record(self, record):
 
         if record.get('name'):
             name = self._replace_unicode(record['name'])
-            if len(name) > 80:
-                name = name[:80]
+            if len(name) > 256:
+                name = name[:256]
             record['name'] = name
 
         if record.get('description'):
@@ -229,7 +219,7 @@ class SpreadsheetMunger:
         if record.get('tx_id'):
             tx_id = self._replace_unicode(record['tx_id'])
             if len(tx_id) > 90:
-                log.warn('Truncated slug: {} to {}'.format(tx_id, tx_id[:90]))
+                print('Truncated slug: {} to {}'.format(tx_id, tx_id[:90]))
                 tx_id = tx_id[:90]
             record['tx_id'] = tx_id
 

--- a/stagecraft/tools/tests/test_import_dashboards.py
+++ b/stagecraft/tools/tests/test_import_dashboards.py
@@ -7,9 +7,9 @@ from hamcrest import (
 
 from stagecraft.apps.dashboards.models import Dashboard
 
-from .spreadsheets import SpreadsheetMunger
-from .import_dashboards import (set_dashboard_attributes,
-                                determine_modules_for_dashboard)
+from ..spreadsheets import SpreadsheetMunger
+from ..import_dashboards import (set_dashboard_attributes,
+                                 determine_modules_for_dashboard)
 
 with open('stagecraft/tools/fixtures/tx.json') as f:
     tx_worksheet = json.loads(f.read())
@@ -44,14 +44,14 @@ def test_attributes_from_record():
     record = munger.merge(tx, names)[0]
 
     dashboard = Dashboard()
-    dashboard = set_dashboard_attributes(dashboard, record, True, False)
+    dashboard = set_dashboard_attributes(dashboard, record, False)
 
     assert_that(dashboard, has_properties({
         'title': record['name'],
         'description': record['description'],
         'costs': record['costs'],
         'other_notes': record['other_notes'],
-        'dashboard_type': 'transaction',
+        'dashboard_type': 'high-volume-transaction',
         'customer_type': record['customer_type'],
         'business_model': record['business_model'],
         'published': False
@@ -76,7 +76,7 @@ def test_published_unmodified():
     }
     dashboard = Dashboard()
     dashboard.published = True
-    dashboard = set_dashboard_attributes(dashboard, record, True, False)
+    dashboard = set_dashboard_attributes(dashboard, record, False)
 
     assert_that(dashboard, has_properties({
         'title': record['name'],
@@ -101,7 +101,7 @@ def test_unset_published_modified():
         'high_volume': False
     }
     dashboard = Dashboard()
-    dashboard = set_dashboard_attributes(dashboard, record, True, False)
+    dashboard = set_dashboard_attributes(dashboard, record, False)
 
     assert_that(dashboard, has_properties({
         'title': record['name'],
@@ -126,7 +126,7 @@ def test_update_published():
         'high_volume': False
     }
     dashboard = Dashboard()
-    dashboard = set_dashboard_attributes(dashboard, record, True, True)
+    dashboard = set_dashboard_attributes(dashboard, record, True)
 
     assert_that(dashboard, has_properties({
         'title': record['name'],

--- a/stagecraft/tools/tests/test_load_organisations.py
+++ b/stagecraft/tools/tests/test_load_organisations.py
@@ -13,9 +13,10 @@ from stagecraft.apps.dashboards.tests.factories.factories import(
 from stagecraft.apps.datasets.tests.factories import DataSetFactory
 
 from ..load_organisations import(
+    key_govuk_org_dict_by_abbreviation,
     load_organisations,
-    add_departments_and_agencies_to_org_dict,
-    build_up_node_dict,
+    create_govuk_org_dict,
+    create_org_dict,
     WHAT_HAPPENED,
     create_nodes)
 
@@ -142,10 +143,10 @@ class LoadOrganisationsTestCase(TestCase):
             equal_to(0))
         assert_that(len(what_happened['link_to_parents_found']), equal_to(1))
         assert_that(
-            len(what_happened['transactions_associated_with_dashboards']),
+            len(what_happened['records_matched_with_dashboards']),
             equal_to(1))
         assert_that(
-            len(what_happened['transactions_not_associated_with_dashboards']),
+            len(what_happened['records_not_matched_with_dashboards']),
             equal_to(0))
 
         # ensure we are clearing between runs
@@ -181,10 +182,10 @@ class LoadOrganisationsTestCase(TestCase):
             equal_to(0))
         assert_that(len(what_happened['link_to_parents_found']), equal_to(1))
         assert_that(
-            len(what_happened['transactions_associated_with_dashboards']),
+            len(what_happened['records_matched_with_dashboards']),
             equal_to(1))
         assert_that(
-            len(what_happened['transactions_not_associated_with_dashboards']),
+            len(what_happened['records_not_matched_with_dashboards']),
             equal_to(0))
 
 # this is the intermediate data format built up from external data
@@ -277,7 +278,7 @@ def test_create_nodes():
 
 
 def test_build_up_node_dict():
-    result = build_up_node_dict(tx_fixture, govuk_fixture)
+    result = create_org_dict(tx_fixture, govuk_fixture)
     assert_that(result, equal_to(expected_result))
 
 
@@ -305,6 +306,6 @@ def test_add_departments_and_agencies_to_org_dict():
             'parents': []
         }
     }
-    org_dict = {}
-    result = add_departments_and_agencies_to_org_dict(org_dict, govuk_fixture)
+    govuk_org_dict = create_govuk_org_dict(govuk_fixture)
+    result = key_govuk_org_dict_by_abbreviation(govuk_org_dict)
     assert_that(result, equal_to(expected_result))

--- a/stagecraft/tools/tests/test_redirect_generation.py
+++ b/stagecraft/tools/tests/test_redirect_generation.py
@@ -1,6 +1,6 @@
 import os
 import json
-from .redirects import generate, write
+from ..redirects import generate, write
 from hamcrest import (
     assert_that, equal_to
 )


### PR DESCRIPTION
This improves the organisation loading code and
updates it against the latest spreadsheet loading code.

It also improves dashboard loading and increases the
length of the title field.

Denormalised fields have been added to dashboards to
improve the loading of /public/dashboards.

This also fixes query parameters for the quarterly
and digital takeup modules.

Django emulates CASCADE which will delete dashboards associated
to organisations when the the organisation is deleted.

Prevent this from happening by setting foreign keys to NULL
beforehand.