### PR TITLE
Add audit logging for authorised actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,10 @@
 /db.sqlite3
 /venv
 /log/*.log
+/log/*.log.*
 /log/*.log.json
-/log/*
+/log/audit/*.log.json
+/log/audit/*.log.json.*
 # Python
 *.pyc
 *.pyo

--- a/stagecraft/settings/development.py
+++ b/stagecraft/settings/development.py
@@ -148,6 +148,15 @@ LOGGING = {
             'formatter': 'logstash_json',
             'filters': ['additional_fields'],
         },
+        'json_audit_log': {
+            'level': 'DEBUG',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': BASE_DIR + "/log/audit/stagecraft.log.json",
+            'maxBytes': 4 * 1024 * 1024,
+            'backupCount': 2,
+            'formatter': 'logstash_json',
+            'filters': ['additional_fields'],
+        },
         'console': {
             'level': 'INFO',
             'class': 'logging.StreamHandler',
@@ -179,6 +188,11 @@ LOGGING = {
         },
         'stagecraft.libs': {
             'handlers': ['console', 'logfile', 'json_log'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+        'stagecraft.audit': {
+            'handlers': ['json_audit_log'],
             'level': 'DEBUG',
             'propagate': True,
         },

--- a/stagecraft/settings/production.py
+++ b/stagecraft/settings/production.py
@@ -60,6 +60,15 @@ LOGGING = {
             'filename': BASE_DIR + "/log/stagecraft.log.json",
             'formatter': 'logstash_json',
         },
+        'json_audit_log': {
+            'level': 'DEBUG',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': BASE_DIR + "/log/audit/stagecraft.log.json",
+            'maxBytes': 4 * 1024 * 1024,
+            'backupCount': 2,
+            'formatter': 'logstash_json',
+            'filters': ['additional_fields'],
+        },
     },
     'loggers': {
         '': {
@@ -80,6 +89,11 @@ LOGGING = {
         'stagecraft.libs': {
             'handlers': ['logfile', 'json_log'],
             'level': 'INFO',
+            'propagate': True,
+        },
+        'stagecraft.audit': {
+            'handlers': ['json_audit_log'],
+            'level': 'DEBUG',
             'propagate': True,
         },
     },


### PR DESCRIPTION
This modifies the authorisation decorator to record
the user UID and request info (path, method, body).

It writes to a separate file, stagecraft.audit.log.json.