### PR TITLE
Replace the published column with a status column on the Dashboard model

### DIFF
--- a/stagecraft/apps/dashboards/migrations/0013_auto__add_field_dashboard_status.py
+++ b/stagecraft/apps/dashboards/migrations/0013_auto__add_field_dashboard_status.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Dashboard.status'
+        db.add_column(u'dashboards_dashboard', 'status',
+                      self.gf('django.db.models.fields.CharField')(default='unpublished', max_length=30),
+                      keep_default=False)
+
+    def backwards(self, orm):
+        # Deleting field 'Dashboard.status'
+        db.delete_column(u'dashboards_dashboard', 'status')
+
+
+    models = {
+        'dashboards.dashboard': {
+            'Meta': {'object_name': 'Dashboard'},
+            '_organisation': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Node']", 'null': 'True', 'db_column': "'organisation_id'", 'blank': 'True'}),
+            'agency_cache': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'dashboards_owned_by_agency'", 'null': 'True', 'to': u"orm['organisation.Node']"}),
+            'business_model': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '31', 'blank': 'True'}),
+            'costs': ('django.db.models.fields.CharField', [], {'max_length': '1500', 'blank': 'True'}),
+            'customer_type': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '30', 'blank': 'True'}),
+            'dashboard_type': ('django.db.models.fields.CharField', [], {'default': "'transaction'", 'max_length': '30'}),
+            'department_cache': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'dashboards_owned_by_department'", 'null': 'True', 'to': u"orm['organisation.Node']"}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'description_extra': ('django.db.models.fields.CharField', [], {'max_length': '400', 'blank': 'True'}),
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'improve_dashboard_message': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'other_notes': ('django.db.models.fields.CharField', [], {'max_length': '1000', 'blank': 'True'}),
+            'page_type': ('django.db.models.fields.CharField', [], {'default': "'dashboard'", 'max_length': '80'}),
+            'published': ('django.db.models.fields.BooleanField', [], {}),
+            'service_cache': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'dashboards_owned_by_service'", 'null': 'True', 'to': u"orm['organisation.Node']"}),
+            'slug': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '90'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'unpublished'", 'max_length': '30'}),
+            'strapline': ('django.db.models.fields.CharField', [], {'default': "'Dashboard'", 'max_length': '40'}),
+            'tagline': ('django.db.models.fields.CharField', [], {'max_length': '400', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'transaction_cache': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'dashboards_owned_by_transaction'", 'null': 'True', 'to': u"orm['organisation.Node']"})
+        },
+        'dashboards.link': {
+            'Meta': {'object_name': 'Link'},
+            'dashboard': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dashboards.Dashboard']"}),
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'link_type': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        'dashboards.module': {
+            'Meta': {'unique_together': "(('dashboard', 'slug'),)", 'object_name': 'Module'},
+            'dashboard': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dashboards.Dashboard']"}),
+            'data_set': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['datasets.DataSet']", 'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'info': ('dbarray.fields.TextArrayField', [], {'blank': 'True'}),
+            'options': ('jsonfield.fields.JSONField', [], {'blank': 'True'}),
+            'order': ('django.db.models.fields.IntegerField', [], {}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dashboards.Module']", 'null': 'True', 'blank': 'True'}),
+            'query_parameters': ('jsonfield.fields.JSONField', [], {'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '60'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '60'}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dashboards.ModuleType']"})
+        },
+        'dashboards.moduletype': {
+            'Meta': {'object_name': 'ModuleType'},
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '25'}),
+            'schema': ('jsonfield.fields.JSONField', [], {})
+        },
+        u'datasets.datagroup': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'DataGroup'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '60'})
+        },
+        u'datasets.dataset': {
+            'Meta': {'ordering': "[u'name']", 'unique_together': "([u'data_group', u'data_type'],)", 'object_name': 'DataSet'},
+            'auto_ids': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'bearer_token': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'capped_size': ('django.db.models.fields.PositiveIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'data_group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['datasets.DataGroup']", 'on_delete': 'models.PROTECT'}),
+            'data_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['datasets.DataType']", 'on_delete': 'models.PROTECT'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'max_age_expected': ('django.db.models.fields.PositiveIntegerField', [], {'default': '86400', 'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '200', 'blank': 'True'}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'queryable': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'raw_queries_allowed': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'realtime': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'upload_filters': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'upload_format': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        u'datasets.datatype': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'DataType'},
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '60'})
+        },
+        u'organisation.node': {
+            'Meta': {'unique_together': "(('name', 'slug', 'typeOf'),)", 'object_name': 'Node'},
+            'abbreviation': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'parents': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['organisation.Node']", 'symmetrical': 'False'}),
+            'slug': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '150'}),
+            'typeOf': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.NodeType']"})
+        },
+        u'organisation.nodetype': {
+            'Meta': {'object_name': 'NodeType'},
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '256'})
+        }
+    }
+
+    complete_apps = ['dashboards']

--- a/stagecraft/apps/dashboards/migrations/0014_set_status.py
+++ b/stagecraft/apps/dashboards/migrations/0014_set_status.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        for dashboard in orm.Dashboard.objects.all():
+            if dashboard.published is True:
+                dashboard.status = 'published'
+                dashboard.save()
+
+    def backwards(self, orm):
+        raise RuntimeError("No point in reversing this migration.")
+
+    models = {
+        'dashboards.dashboard': {
+            'Meta': {'object_name': 'Dashboard'},
+            '_organisation': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Node']", 'null': 'True', 'db_column': "'organisation_id'", 'blank': 'True'}),
+            'agency_cache': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'dashboards_owned_by_agency'", 'null': 'True', 'to': u"orm['organisation.Node']"}),
+            'business_model': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '31', 'blank': 'True'}),
+            'costs': ('django.db.models.fields.CharField', [], {'max_length': '1500', 'blank': 'True'}),
+            'customer_type': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '30', 'blank': 'True'}),
+            'dashboard_type': ('django.db.models.fields.CharField', [], {'default': "'transaction'", 'max_length': '30'}),
+            'department_cache': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'dashboards_owned_by_department'", 'null': 'True', 'to': u"orm['organisation.Node']"}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'description_extra': ('django.db.models.fields.CharField', [], {'max_length': '400', 'blank': 'True'}),
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'improve_dashboard_message': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'other_notes': ('django.db.models.fields.CharField', [], {'max_length': '1000', 'blank': 'True'}),
+            'page_type': ('django.db.models.fields.CharField', [], {'default': "'dashboard'", 'max_length': '80'}),
+            'published': ('django.db.models.fields.BooleanField', [], {}),
+            'service_cache': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'dashboards_owned_by_service'", 'null': 'True', 'to': u"orm['organisation.Node']"}),
+            'slug': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '90'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'unpublished'", 'max_length': '30'}),
+            'strapline': ('django.db.models.fields.CharField', [], {'default': "'Dashboard'", 'max_length': '40'}),
+            'tagline': ('django.db.models.fields.CharField', [], {'max_length': '400', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'transaction_cache': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'dashboards_owned_by_transaction'", 'null': 'True', 'to': u"orm['organisation.Node']"})
+        },
+        'dashboards.link': {
+            'Meta': {'object_name': 'Link'},
+            'dashboard': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dashboards.Dashboard']"}),
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'link_type': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        'dashboards.module': {
+            'Meta': {'unique_together': "(('dashboard', 'slug'),)", 'object_name': 'Module'},
+            'dashboard': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dashboards.Dashboard']"}),
+            'data_set': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['datasets.DataSet']", 'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'info': ('dbarray.fields.TextArrayField', [], {'blank': 'True'}),
+            'options': ('jsonfield.fields.JSONField', [], {'blank': 'True'}),
+            'order': ('django.db.models.fields.IntegerField', [], {}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dashboards.Module']", 'null': 'True', 'blank': 'True'}),
+            'query_parameters': ('jsonfield.fields.JSONField', [], {'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '60'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '60'}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dashboards.ModuleType']"})
+        },
+        'dashboards.moduletype': {
+            'Meta': {'object_name': 'ModuleType'},
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '25'}),
+            'schema': ('jsonfield.fields.JSONField', [], {})
+        },
+        u'datasets.datagroup': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'DataGroup'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '60'})
+        },
+        u'datasets.dataset': {
+            'Meta': {'ordering': "[u'name']", 'unique_together': "([u'data_group', u'data_type'],)", 'object_name': 'DataSet'},
+            'auto_ids': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'bearer_token': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'capped_size': ('django.db.models.fields.PositiveIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'data_group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['datasets.DataGroup']", 'on_delete': 'models.PROTECT'}),
+            'data_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['datasets.DataType']", 'on_delete': 'models.PROTECT'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'max_age_expected': ('django.db.models.fields.PositiveIntegerField', [], {'default': '86400', 'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '200', 'blank': 'True'}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'queryable': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'raw_queries_allowed': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'realtime': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'upload_filters': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'upload_format': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        u'datasets.datatype': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'DataType'},
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '60'})
+        },
+        u'organisation.node': {
+            'Meta': {'unique_together': "(('name', 'slug', 'typeOf'),)", 'object_name': 'Node'},
+            'abbreviation': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'parents': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['organisation.Node']", 'symmetrical': 'False'}),
+            'slug': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '150'}),
+            'typeOf': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.NodeType']"})
+        },
+        u'organisation.nodetype': {
+            'Meta': {'object_name': 'NodeType'},
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '256'})
+        }
+    }
+
+    complete_apps = ['dashboards']
+    symmetrical = True

--- a/stagecraft/apps/dashboards/migrations/0015_auto__del_field_dashboard_published.py
+++ b/stagecraft/apps/dashboards/migrations/0015_auto__del_field_dashboard_published.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'Dashboard.published'
+        db.delete_column(u'dashboards_dashboard', 'published')
+
+
+    def backwards(self, orm):
+
+        # User chose to not deal with backwards NULL issues for 'Dashboard.published'
+        raise RuntimeError("Cannot reverse this migration. 'Dashboard.published' and its values cannot be restored.")
+        
+        # The following code is provided here to aid in writing a correct migration        # Adding field 'Dashboard.published'
+        db.add_column(u'dashboards_dashboard', 'published',
+                      self.gf('django.db.models.fields.BooleanField')(),
+                      keep_default=False)
+
+
+    models = {
+        'dashboards.dashboard': {
+            'Meta': {'object_name': 'Dashboard'},
+            '_organisation': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Node']", 'null': 'True', 'db_column': "'organisation_id'", 'blank': 'True'}),
+            'agency_cache': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'dashboards_owned_by_agency'", 'null': 'True', 'to': u"orm['organisation.Node']"}),
+            'business_model': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '31', 'blank': 'True'}),
+            'costs': ('django.db.models.fields.CharField', [], {'max_length': '1500', 'blank': 'True'}),
+            'customer_type': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '30', 'blank': 'True'}),
+            'dashboard_type': ('django.db.models.fields.CharField', [], {'default': "'transaction'", 'max_length': '30'}),
+            'department_cache': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'dashboards_owned_by_department'", 'null': 'True', 'to': u"orm['organisation.Node']"}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'description_extra': ('django.db.models.fields.CharField', [], {'max_length': '400', 'blank': 'True'}),
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'improve_dashboard_message': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'other_notes': ('django.db.models.fields.CharField', [], {'max_length': '1000', 'blank': 'True'}),
+            'page_type': ('django.db.models.fields.CharField', [], {'default': "'dashboard'", 'max_length': '80'}),
+            'service_cache': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'dashboards_owned_by_service'", 'null': 'True', 'to': u"orm['organisation.Node']"}),
+            'slug': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '90'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'unpublished'", 'max_length': '30'}),
+            'strapline': ('django.db.models.fields.CharField', [], {'default': "'Dashboard'", 'max_length': '40'}),
+            'tagline': ('django.db.models.fields.CharField', [], {'max_length': '400', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'transaction_cache': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'dashboards_owned_by_transaction'", 'null': 'True', 'to': u"orm['organisation.Node']"})
+        },
+        'dashboards.link': {
+            'Meta': {'object_name': 'Link'},
+            'dashboard': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dashboards.Dashboard']"}),
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'link_type': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        'dashboards.module': {
+            'Meta': {'unique_together': "(('dashboard', 'slug'),)", 'object_name': 'Module'},
+            'dashboard': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dashboards.Dashboard']"}),
+            'data_set': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['datasets.DataSet']", 'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'info': ('dbarray.fields.TextArrayField', [], {'blank': 'True'}),
+            'options': ('jsonfield.fields.JSONField', [], {'blank': 'True'}),
+            'order': ('django.db.models.fields.IntegerField', [], {}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dashboards.Module']", 'null': 'True', 'blank': 'True'}),
+            'query_parameters': ('jsonfield.fields.JSONField', [], {'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '60'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '60'}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dashboards.ModuleType']"})
+        },
+        'dashboards.moduletype': {
+            'Meta': {'object_name': 'ModuleType'},
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '25'}),
+            'schema': ('jsonfield.fields.JSONField', [], {})
+        },
+        u'datasets.datagroup': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'DataGroup'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '60'})
+        },
+        u'datasets.dataset': {
+            'Meta': {'ordering': "[u'name']", 'unique_together': "([u'data_group', u'data_type'],)", 'object_name': 'DataSet'},
+            'auto_ids': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'bearer_token': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'capped_size': ('django.db.models.fields.PositiveIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'data_group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['datasets.DataGroup']", 'on_delete': 'models.PROTECT'}),
+            'data_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['datasets.DataType']", 'on_delete': 'models.PROTECT'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'max_age_expected': ('django.db.models.fields.PositiveIntegerField', [], {'default': '86400', 'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '200', 'blank': 'True'}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'queryable': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'raw_queries_allowed': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'realtime': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'upload_filters': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'upload_format': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        u'datasets.datatype': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'DataType'},
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '60'})
+        },
+        u'organisation.node': {
+            'Meta': {'unique_together': "(('name', 'slug', 'typeOf'),)", 'object_name': 'Node'},
+            'abbreviation': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'parents': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['organisation.Node']", 'symmetrical': 'False'}),
+            'slug': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '150'}),
+            'typeOf': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.NodeType']"})
+        },
+        u'organisation.nodetype': {
+            'Meta': {'object_name': 'NodeType'},
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '256'})
+        }
+    }
+
+    complete_apps = ['dashboards']

--- a/stagecraft/apps/dashboards/tests/factories/factories.py
+++ b/stagecraft/apps/dashboards/tests/factories/factories.py
@@ -9,7 +9,7 @@ class DashboardFactory(factory.DjangoModelFactory):
     class Meta:
         model = Dashboard
 
-    published = True
+    status = 'published'
     title = "title"
     slug = factory.Sequence(lambda n: 'slug%s' % n)
 

--- a/stagecraft/apps/dashboards/tests/models/test_dashboard.py
+++ b/stagecraft/apps/dashboards/tests/models/test_dashboard.py
@@ -22,6 +22,30 @@ class DashboardTestCase(TransactionTestCase):
     def setUp(self):
         self.dashboard = DashboardFactory()
 
+    def tearDown(self):
+        self.dashboard.delete()
+
+    def test_dashboard_is_unpublished_when_status_is_unpublished(self):
+        self.dashboard.status = 'unpublished'
+        assert_that(self.dashboard.published, is_(False))
+
+    def test_dashboard_is_unpublished_when_status_is_in_review(self):
+        self.dashboard.status = 'in-review'
+        assert_that(self.dashboard.published, is_(False))
+
+    def test_dashboard_is_published_when_status_is_published(self):
+        self.dashboard.status = 'published'
+        assert_that(self.dashboard.published, is_(True))
+
+    def test_publishing_a_dashboard_changes_its_status_to_published(self):
+        dashboard = DashboardFactory(status='unpublished')
+        dashboard.published = True
+        assert_that(dashboard.status, equal_to('published'))
+
+    def test_unpublishing_a_dashboard_changes_its_status_to_unpublished(self):
+        self.dashboard.published = False
+        assert_that(self.dashboard.status, equal_to('unpublished'))
+
     def test_class_level_list_for_spotlight_returns_minimal_json_array(self):
         dashboard_two = DashboardFactory()
         organisation = ServiceFactory()
@@ -39,6 +63,12 @@ class DashboardTestCase(TransactionTestCase):
                     has_entries({
                         'slug': starts_with('slug'),
                         'title': 'title',
+                        'dashboard-type': 'transaction'
+                    }))
+        assert_that(list_for_spotlight['items'][1],
+                    has_entries({
+                        'slug': starts_with('slug'),
+                        'title': 'title',
                         'dashboard-type': 'transaction',
                         'department': has_entries({
                             'title': starts_with('department'),
@@ -52,12 +82,6 @@ class DashboardTestCase(TransactionTestCase):
                             'title': starts_with('service'),
                             'abbr': starts_with('abbreviation')
                         })
-                    }))
-        assert_that(list_for_spotlight['items'][1],
-                    has_entries({
-                        'slug': starts_with('slug'),
-                        'title': 'title',
-                        'dashboard-type': 'transaction'
                     }))
 
     def test_spotlightify_no_modules(self):

--- a/stagecraft/apps/dashboards/tests/views/test_dashboard.py
+++ b/stagecraft/apps/dashboards/tests/views/test_dashboard.py
@@ -30,7 +30,11 @@ from nose.tools import nottest
 class DashboardViewsListTestCase(TestCase):
 
     def test_list_dashboards_lists_dashboards(self):
-        DashboardFactory(slug='dashboard', title='Dashboard', published=True)
+        DashboardFactory(
+            slug='dashboard',
+            title='Dashboard',
+            status='published'
+        )
         resp = self.client.get(
             '/dashboards',
             HTTP_AUTHORIZATION='Bearer development-oauth-access-token')

--- a/stagecraft/apps/dashboards/views/dashboard.py
+++ b/stagecraft/apps/dashboards/views/dashboard.py
@@ -107,6 +107,7 @@ def list_dashboards(user, request):
                 reverse('dashboard', kwargs={'identifier': item.slug})),
             'public-url': '{0}/performance/{1}'.format(
                 settings.GOVUK_ROOT, item.slug),
+            'status': item.status,
             'published': item.published
         })
 


### PR DESCRIPTION
Add a status field to the Dashboard model which can hold one of the following values: 'unpublished', 'in-review' or 'published'.

Remove the published field and instead derive its value from the status attribute:

- When status is 'unpublished' or 'in-review', published is False
- When status is 'published', published is True

The published attribute can also be used to set the status field:

- When published is set to True, status is set to 'published'
- When published is set to False, status is set to 'unpublished'

This change is in support of story: https://www.pivotaltracker.com/story/show/89863072
