### PR TITLE
Log out token when outputting audit logs

### DIFF
--- a/stagecraft/libs/authorization/http.py
+++ b/stagecraft/libs/authorization/http.py
@@ -96,7 +96,9 @@ def permission_required(permission):
             elif not has_permission:
                 return forbidden(request, 'user lacks permission.')
             else:
-                extra = {}
+                extra = {
+                    'token': access_token,
+                }
                 if request.method in ['POST', 'PUT']:
                     extra['body'] = request.body
                 audit_logger.info('Authorised action', extra=extra)


### PR DESCRIPTION
We really need to know who it was that was doing an authorized action in
order for the logs to be useful if anything naughty is done.