### PR TITLE
Upgrade to latest 1.6.x django

### DIFF
--- a/requirements/_common.txt
+++ b/requirements/_common.txt
@@ -1,6 +1,6 @@
 # requirements/common.txt: Used on *all* environments.
 
-django==1.6.5
+django==1.6.11
 django-dbarray==0.2
 django-mptt==0.6.1
 django-reversion==1.8.0


### PR DESCRIPTION
As part of upgrading to a supported version, upgrade to the latest
1.6.x, then upgrade to 1.7.x etc.