### PR TITLE
Improve resource view

### DIFF
--- a/stagecraft/apps/dashboards/views/module.py
+++ b/stagecraft/apps/dashboards/views/module.py
@@ -215,6 +215,10 @@ class ModuleView(ResourceView):
         # block direct creation of modules for now.
         return HttpResponse('', status=405)
 
+    def put(self, request, **kwargs):
+        # block direct creation of modules for now.
+        return HttpResponse('', status=405)
+
     @staticmethod
     def serialize(model):
         return model.serialize()

--- a/stagecraft/apps/datasets/tests/views/test_data_set.py
+++ b/stagecraft/apps/datasets/tests/views/test_data_set.py
@@ -706,26 +706,6 @@ class DataSetsViewsTestCase(TestCase):
             json.loads(resp.content)['message'],
             "No data type with name 'wibble' found")
 
-    def test_put_does_nothing(self):
-        data_set = {
-            'data_type': 'type1',
-            'realtime': False,
-            'auto_ids': 'aa,bb',
-            'max_age_expected': 86400,
-            'data_group': 'group1',
-            'upload_filters': 'backdrop.filter.1',
-            'queryable': True,
-            'upload_format': '',
-            'raw_queries_allowed': True,
-            'published': False,
-        }
-        resp = self.client.put(
-            '/data-sets',
-            data=json.dumps(data_set),
-            HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
-            content_type='application/json')
-        assert_equal(resp.status_code, 405)
-
     def test_users_for_nonexistant_dataset_returns_empty_list(self):
         resp = self.client.get(
             '/data-sets/example-data-set/users',

--- a/stagecraft/apps/datasets/views/data_group.py
+++ b/stagecraft/apps/datasets/views/data_group.py
@@ -8,6 +8,9 @@ from stagecraft.libs.authorization.http import permission_required
 
 class DataGroupView(ResourceView):
     model = DataGroup
+    id_fields = {
+        'name': '[\w-]+',
+    }
     list_filters = {
         "name": "name"
     }

--- a/stagecraft/apps/datasets/views/data_set.py
+++ b/stagecraft/apps/datasets/views/data_set.py
@@ -37,7 +37,9 @@ class DataSetView(ResourceView):
         'data-type': 'data_type__name',
         'data_type': 'data_type__name',
     }
-    id_field = 'name'
+    id_fields = {
+        'name': '[\w-]+',
+    }
     generated_id = False
     schema = {
         "$schema": "http://json-schema.org/schema#",

--- a/stagecraft/apps/organisation/tests/test_views.py
+++ b/stagecraft/apps/organisation/tests/test_views.py
@@ -49,16 +49,12 @@ class NodeViewsTestCase(TestCase):
         )
         brie.parents.add(cheese)
 
-    def test_root_view_only_get_post(self):
+    def test_root_view_doesnt_delete(self):
         delete_resp = self.client.delete(
-            '/organisation/node',
-            HTTP_AUTHORIZATION='Bearer development-oauth-access-token')
-        put_resp = self.client.put(
             '/organisation/node',
             HTTP_AUTHORIZATION='Bearer development-oauth-access-token')
 
         assert_that(delete_resp.status_code, equal_to(405))
-        assert_that(put_resp.status_code, equal_to(405))
 
     def test_list_nodes(self):
         resp = self.client.get(
@@ -376,16 +372,12 @@ class NodeTypeViewsTestCase(TestCase):
         )
         brie.parents.add(cheese)
 
-    def test_root_view_only_get_post(self):
+    def test_root_view_doesnt_delete(self):
         delete_resp = self.client.delete(
-            '/organisation/type',
-            HTTP_AUTHORIZATION='Bearer development-oauth-access-token')
-        put_resp = self.client.put(
             '/organisation/type',
             HTTP_AUTHORIZATION='Bearer development-oauth-access-token')
 
         assert_that(delete_resp.status_code, equal_to(405))
-        assert_that(put_resp.status_code, equal_to(405))
 
     def test_list_types(self):
         resp = self.client.get(

--- a/stagecraft/apps/organisation/views.py
+++ b/stagecraft/apps/organisation/views.py
@@ -99,6 +99,12 @@ class NodeView(ResourceView):
         except NodeType.DoesNotExist:
             return HttpResponse('no NodeType found', status=400)
 
+        model.name = model_json['name']
+        model.slug = model_json.get('slug', None)
+        model.abbreviation = model_json.get('abbreviation', None)
+        model.typeOf = node_type
+
+    def update_relationships(self, model, model_json, request):
         if 'parent_id' in model_json:
             parent_id = model_json['parent_id']
             if not is_uuid(parent_id):
@@ -108,16 +114,7 @@ class NodeView(ResourceView):
                 parent_node = Node.objects.get(id=parent_id)
             except Node.DoesNotExist:
                 return HttpResponse('parent not found', status=400)
-        else:
-            parent_node = None
 
-        model.name = model_json['name']
-        model.slug = model_json.get('slug', None)
-        model.abbreviation = model_json.get('abbreviation', None)
-        model.typeOf = node_type
-
-        if parent_node is not None:
-            model.save()
             model.parents.add(parent_node)
 
     @staticmethod

--- a/stagecraft/urls.py
+++ b/stagecraft/urls.py
@@ -87,11 +87,7 @@ urlpatterns = patterns(
     resource_url('organisation/type', organisation_views.NodeTypeView),
     resource_url('transform-type', transforms_views.TransformTypeView),
     resource_url('transform', transforms_views.TransformView),
-    resource_url('data-sets',
-                 datasets_views.DataSetView,
-                 id_matcher='<name>[\w-]+'),
-    resource_url('data-groups',
-                 datagroups_views.DataGroupView,
-                 id_matcher='<name>[\w-]+'),
+    resource_url('data-sets', datasets_views.DataSetView),
+    resource_url('data-groups', datagroups_views.DataGroupView),
     resource_url('module', module_views.ModuleView),
 )


### PR DESCRIPTION
Adding a `PUT` endpoint, allowing for better customisation for the id referencing resources (locality and multiple) and splitting up the updating of model fields and the relationships that model has.