### PR TITLE
Module migrations for updates schemas

### DIFF
--- a/stagecraft/apps/dashboards/migrations/0016_fix_module_schemas.py
+++ b/stagecraft/apps/dashboards/migrations/0016_fix_module_schemas.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        to_pop = [
+            {'grouped_timeseries': [
+                'category',
+                'show-total-lines',
+                'currency',
+                'line-label-links',
+                'format-options',
+                'magnitude',
+                'slug',
+                'description',
+                'data-source',
+                'module-type',
+                'title',
+                'info']},
+            {'single_timeseries': [
+                'trim',
+                'category',
+                'use_stack',
+                'show-line-labels',
+                'show-total-lines',
+                'one-hundred-percent']},
+            {'bar_chart_with_number': [
+                'show-line-labels',
+                'tabs',
+                'category',
+                'show-total-lines',
+                'use_stack',
+                'matching-attribute',
+                'slug',
+                'module-type',
+                'title']},
+            {'completion_rate': [
+                'format-options',
+                'one-hundred-percent',
+                'show-total-lines',
+                'show-line-labels',
+                'use_stack']},
+            {'kpi': [
+                'axes',
+                'period']}
+        ]
+
+        for item in to_pop:
+            modules = [m for m in orm.Module.objects.filter(
+                type__name=list(item.keys())[0])]
+            for module in modules:
+                for option_key in list(item.values())[0]:
+                    module.options.pop(option_key, None)
+                module.save()
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+
+    models = {
+        'dashboards.dashboard': {
+            'Meta': {'object_name': 'Dashboard'},
+            '_organisation': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Node']", 'null': 'True', 'db_column': "'organisation_id'", 'blank': 'True'}),
+            'agency_cache': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'dashboards_owned_by_agency'", 'null': 'True', 'to': u"orm['organisation.Node']"}),
+            'business_model': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '31', 'blank': 'True'}),
+            'costs': ('django.db.models.fields.CharField', [], {'max_length': '1500', 'blank': 'True'}),
+            'customer_type': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '30', 'blank': 'True'}),
+            'dashboard_type': ('django.db.models.fields.CharField', [], {'default': "'transaction'", 'max_length': '30'}),
+            'department_cache': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'dashboards_owned_by_department'", 'null': 'True', 'to': u"orm['organisation.Node']"}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'description_extra': ('django.db.models.fields.CharField', [], {'max_length': '400', 'blank': 'True'}),
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'improve_dashboard_message': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'other_notes': ('django.db.models.fields.CharField', [], {'max_length': '1000', 'blank': 'True'}),
+            'page_type': ('django.db.models.fields.CharField', [], {'default': "'dashboard'", 'max_length': '80'}),
+            'service_cache': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'dashboards_owned_by_service'", 'null': 'True', 'to': u"orm['organisation.Node']"}),
+            'slug': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '90'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'unpublished'", 'max_length': '30'}),
+            'strapline': ('django.db.models.fields.CharField', [], {'default': "'Dashboard'", 'max_length': '40'}),
+            'tagline': ('django.db.models.fields.CharField', [], {'max_length': '400', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'transaction_cache': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'dashboards_owned_by_transaction'", 'null': 'True', 'to': u"orm['organisation.Node']"})
+        },
+        'dashboards.link': {
+            'Meta': {'object_name': 'Link'},
+            'dashboard': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dashboards.Dashboard']"}),
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'link_type': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        'dashboards.module': {
+            'Meta': {'unique_together': "(('dashboard', 'slug'),)", 'object_name': 'Module'},
+            'dashboard': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dashboards.Dashboard']"}),
+            'data_set': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['datasets.DataSet']", 'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'info': ('dbarray.fields.TextArrayField', [], {'blank': 'True'}),
+            'options': ('jsonfield.fields.JSONField', [], {'blank': 'True'}),
+            'order': ('django.db.models.fields.IntegerField', [], {}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dashboards.Module']", 'null': 'True', 'blank': 'True'}),
+            'query_parameters': ('jsonfield.fields.JSONField', [], {'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '60'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '60'}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dashboards.ModuleType']"})
+        },
+        'dashboards.moduletype': {
+            'Meta': {'object_name': 'ModuleType'},
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '25'}),
+            'schema': ('jsonfield.fields.JSONField', [], {})
+        },
+        u'datasets.datagroup': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'DataGroup'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '60'})
+        },
+        u'datasets.dataset': {
+            'Meta': {'ordering': "[u'name']", 'unique_together': "([u'data_group', u'data_type'],)", 'object_name': 'DataSet'},
+            'auto_ids': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'bearer_token': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'capped_size': ('django.db.models.fields.PositiveIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'data_group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['datasets.DataGroup']", 'on_delete': 'models.PROTECT'}),
+            'data_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['datasets.DataType']", 'on_delete': 'models.PROTECT'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'max_age_expected': ('django.db.models.fields.PositiveIntegerField', [], {'default': '86400', 'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '200', 'blank': 'True'}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'queryable': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'raw_queries_allowed': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'realtime': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'upload_filters': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'upload_format': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        u'datasets.datatype': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'DataType'},
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '60'})
+        },
+        u'organisation.node': {
+            'Meta': {'unique_together': "(('name', 'slug', 'typeOf'),)", 'object_name': 'Node'},
+            'abbreviation': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'parents': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['organisation.Node']", 'symmetrical': 'False'}),
+            'slug': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '150'}),
+            'typeOf': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.NodeType']"})
+        },
+        u'organisation.nodetype': {
+            'Meta': {'object_name': 'NodeType'},
+            'id': ('uuidfield.fields.UUIDField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '256'})
+        }
+    }
+
+    complete_apps = ['dashboards']
+    symmetrical = True

--- a/tools/import_schemas/schema/modules_json/bar_chart_with_number_schema.json
+++ b/tools/import_schemas/schema/modules_json/bar_chart_with_number_schema.json
@@ -4,8 +4,7 @@
   "additionalProperties": false,
   "properties": {
     "value-attribute": {
-      "type": "string",
-      "required": true
+      "type": "string"
     },
     "format": {
       "oneOf": [

--- a/tools/import_schemas/schema/modules_json/grouped_timeseries_schema.json
+++ b/tools/import_schemas/schema/modules_json/grouped_timeseries_schema.json
@@ -94,8 +94,7 @@
       "type": "object",
       "properties": {
         "label": {
-          "type": "string",
-          "required": true
+          "type": "string"
         },
         "key": {
           "oneOf": [


### PR DESCRIPTION
As part of the work to tighten up the module schemas for stagecraft we've had to create a data migration for the modules.

It would be nice if whoever is going to merge this PR will also run the migration script against preview to verify the updates to the module data is non breaking.

After that we can organise a time to run it against the production dashboard configs.