### PR TITLE
Add scripts for debugging org structure

### DIFF
--- a/stagecraft/apps/organisation/models.py
+++ b/stagecraft/apps/organisation/models.py
@@ -34,9 +34,17 @@ class NodeManager(models.Manager):
         ORDER BY node_parents.depth DESC
         ''', [node.id])
 
+    def immediate_descendants(self, node):
+        return self.raw('''
+        SELECT organisation_node.*
+        FROM organisation_node_parents
+          INNER JOIN organisation_node
+          ON organisation_node.id = organisation_node_parents.from_node_id
+        WHERE organisation_node_parents.to_node_id = %s
+        ''', [node.id])
+
     def get_queryset(self):
-        return super(NodeManager, self).get_queryset().select_related(
-            'typeOf')
+        return super(NodeManager, self).get_queryset().select_related('typeOf')
 
 
 class NodeType(models.Model):
@@ -78,6 +86,9 @@ class Node(models.Model):
 
     def get_ancestors(self, include_self=True):
         return Node.objects.ancestors_of(self, include_self)
+
+    def get_immediate_descendants(self):
+        return Node.objects.immediate_descendants(self)
 
     def spotlightify(self):
         node = {}

--- a/stagecraft/apps/organisation/tests/test_models.py
+++ b/stagecraft/apps/organisation/tests/test_models.py
@@ -57,6 +57,21 @@ class NodeTestCase(TestCase):
 
         assert_that(calling(str).with_args(node), is_not(raises(ValueError)))
 
+    def test_get_immediate_descendants(self):
+        root = Node.objects.create(name='root', typeOf=self.node_type)
+        intermediate = Node.objects.create(name='intermediate',
+                                           typeOf=self.node_type)
+        intermediate.parents.add(root)
+        intermediate.save()
+
+        leaf = Node.objects.create(name='leaf', typeOf=self.node_type)
+        leaf.parents.add(intermediate)
+        leaf.save()
+
+        immediate_descendants = list(root.get_immediate_descendants())
+        assert_that(len(immediate_descendants), is_(1))
+        assert_that(a_node_has_name('intermediate', immediate_descendants))
+
 
 class NodeTypeTestCase(TestCase):
 

--- a/stagecraft/tools/README.md
+++ b/stagecraft/tools/README.md
@@ -1,0 +1,11 @@
+These scripts should be run from the repository root,
+with an activated virtualenv.
+
+You may also need to set the environment variable `DJANGO_SETTINGS_MODULE`
+appropriately.
+
+Invoke a script as follows:
+
+```
+python -m stagecraft.tools.script arg1 arg2
+```

--- a/stagecraft/tools/print_dashboard_ancestors.py
+++ b/stagecraft/tools/print_dashboard_ancestors.py
@@ -1,0 +1,24 @@
+import sys
+
+import django
+django.setup()
+
+from stagecraft.apps.dashboards.models import Dashboard
+
+
+def print_ancestors(slug):
+    try:
+        dashboard = Dashboard.objects.get(slug=slug)
+    except Dashboard.DoesNotExist:
+        print('Dashboard not found')
+        return None
+    ancestor_slugs = map(lambda x: x.slug,
+                         dashboard.organisation.get_ancestors())
+    print('%s' % ' -> '.join(map(str, ancestor_slugs + [slug])))
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        print('Please supply an dashboard slug')
+        sys.exit(1)
+    print_ancestors(sys.argv[1])

--- a/stagecraft/tools/print_node_descendants.py
+++ b/stagecraft/tools/print_node_descendants.py
@@ -1,0 +1,42 @@
+import sys
+
+import django
+django.setup()
+
+from stagecraft.apps.organisation.models import Node
+from stagecraft.apps.dashboards.models import Dashboard
+
+
+def print_paths(slug):
+    try:
+        node = Node.objects.get(slug=slug)
+    except Node.DoesNotExist:
+        print('Node not found')
+        return None
+    dfs(node)
+
+
+def dfs(node, path=None):
+    if path is None:
+        path = []
+    path.append(node.slug)
+
+    descendants = list(node.get_immediate_descendants())
+    if descendants:
+        for descendant in descendants:
+            dfs(descendant, path[:])
+    else:
+        dashboards = Dashboard.objects.filter(
+            _organisation=Node.objects.get(slug=path[-1]))
+        if dashboards:
+            for dashboard in dashboards:
+                print('%s' % ' -> '.join(map(str, path + [dashboard.slug])))
+        else:
+            print('%s' % ' -> '.join(map(str, path)))
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        print('Please supply an organisation slug')
+        sys.exit(1)
+    print_paths(sys.argv[1])


### PR DESCRIPTION
This adds two scripts: one for printing the
edges from a node to its descendants (using
depth-first search), and one for printing
the edges from a dashboard to its root
ancestor.

These should help us debug issues with the
organisation graph.