### PR TITLE
Permit agencies to have no owning department

### DIFF
--- a/stagecraft/apps/dashboards/models/dashboard.py
+++ b/stagecraft/apps/dashboards/models/dashboard.py
@@ -353,10 +353,7 @@ class Dashboard(models.Model):
             for node in self.agency().get_ancestors(include_self=False):
                 if node.typeOf.name == 'department':
                     dept = node
-            if dept is not None:
-                return dept
-            else:
-                raise ValueError
+            return dept
         else:
             if self.organisation is not None:
                 for node in self.organisation.get_ancestors():

--- a/stagecraft/apps/dashboards/tests/models/test_dashboard.py
+++ b/stagecraft/apps/dashboards/tests/models/test_dashboard.py
@@ -297,9 +297,9 @@ class DashboardTestCase(TransactionTestCase):
         assert_that(
             self.dashboard.department(), equal_to(agency.parents.first()))
 
-    def test_department_throws_exception_when_agency_has_no_department(self):
+    def test_department_is_none_when_agency_has_no_department(self):
         self.dashboard.organisation = AgencyFactory()
-        assert_that(calling(self.dashboard.department), raises(ValueError))
+        assert_that(self.dashboard.department(), is_(none()))
 
     def test_department_returns_none_when_organisation_is_none(self):
         assert_that(self.dashboard.department(), is_(none()))


### PR DESCRIPTION
Previously it was assumed that all agencies must
be owned by a department, and would result in
a ValueError when trying to retrieve a related
dashboard. But in certain cases (e.g. HMRC) there
is no owning department. This removes the
restriction.