### PR TITLE
Capture details about validation failures

### DIFF
--- a/import_schemas.py
+++ b/import_schemas.py
@@ -83,11 +83,16 @@ def validate_all_modules():
 def validate_all_modules_against_files():
     for module in Module.objects.all():
         schema = get_schema_for_module_type(module.type.name)
-        jsonschema.validate(module.options, schema)
-        print "======"
-        print "{} valid in {} dashboard".format(
-            module.slug, module.dashboard.slug)
-        print "^====="
+        try:
+            jsonschema.validate(module.options, schema)
+            print "======"
+            print "{} valid in {} dashboard".format(
+                module.slug, module.dashboard.slug)
+            print "^====="
+        except jsonschema.exceptions.ValidationError as e:
+            print 'failure validating {} in {} dashboard'.format(
+                module.slug, module.dashboard.slug)
+            raise e
     return True
 
 


### PR DESCRIPTION
If a dashboard / module isn’t valid according to a schema, tell the
user which one failed.