### PR TITLE
Check permissions for Anonymous Users

### DIFF
--- a/stagecraft/libs/authorization/tests/test_http.py
+++ b/stagecraft/libs/authorization/tests/test_http.py
@@ -177,8 +177,29 @@ class CheckPermissionTestCase(TestCase):
 
             assert_that(has_permission, equal_to(False))
 
-    # def test_anon_user_if_no_token(self):
-    #     assert_that(True, is_(False))
+    def test_anon_user_if_no_token(self):
+        settings.USE_DEVELOPMENT_USERS = False
+
+        (user, has_permission) = check_permission(None, None, True)
+
+        assert_that(has_permission, equal_to(True))
+        assert_that(user.get('name'), equal_to('Anonymous'))
+
+    def test_no_user_if_no_token_and_anon_user_not_allowed(self):
+        settings.USE_DEVELOPMENT_USERS = False
+
+        (user, has_permission) = check_permission(None, None, False)
+
+        assert_that(has_permission, equal_to(False))
+        assert_that(user, is_(None))
+
+    def test_anon_user_if_permission_requested(self):
+        settings.USE_DEVELOPMENT_USERS = False
+
+        (user, has_permission) = check_permission(None, 'permission', True)
+
+        assert_that(has_permission, equal_to(False))
+        assert_that(user.get('name'), equal_to('Anonymous'))
 
 
 class AuthorizeTestCase(TestCase):


### PR DESCRIPTION
DataSets always require a user. This is not true of all views that
inherit from ResourceView.  Support for Anonymous users was added
during a previous commit to make module dashboard views inherit
from ResourceView:

https://github.com/alphagov/stagecraft/commit/a4b9ad17c64bcbe16b922b87b2509e664ee44bb8

Tests have been added to support this feature.