### PR TITLE
Update standalone scripts for Django 1.7

### DIFF
--- a/stagecraft/tools/import_dashboards.py
+++ b/stagecraft/tools/import_dashboards.py
@@ -4,6 +4,9 @@ import sys
 
 import requests
 
+import django
+django.setup()
+
 from django.db import IntegrityError
 from django.db.utils import DataError
 from django.core.exceptions import ValidationError

--- a/stagecraft/tools/import_organisations.py
+++ b/stagecraft/tools/import_organisations.py
@@ -6,6 +6,9 @@ import os
 import requests
 import sys
 
+import django
+django.setup()
+
 from collections import defaultdict
 from django.db import connection
 from pprint import pprint

--- a/stagecraft/tools/load_organisations.py
+++ b/stagecraft/tools/load_organisations.py
@@ -4,6 +4,9 @@ import sys
 
 from collections import defaultdict
 
+import django
+django.setup()
+
 from django.db.utils import DataError, IntegrityError
 
 from stagecraft.apps.organisation.models import Node, NodeType


### PR DESCRIPTION
The AppRegistry, new in Django 1.7, requires
setup before it can be used outside of a
django application.

This adds the necessary setup step to our
standalone scripts.