### PR TITLE
Support anonymous users and reinstate JSON errors

### DIFF
--- a/stagecraft/apps/dashboards/tests/views/test_dashboard.py
+++ b/stagecraft/apps/dashboards/tests/views/test_dashboard.py
@@ -3,7 +3,7 @@ import json
 
 from django.test import TestCase
 from hamcrest import (
-    assert_that, equal_to, is_, none, has_property,
+    assert_that, equal_to, is_, has_property,
     contains, has_entry, has_entries, has_key, starts_with, has_length
 )
 from django_nose.tools import assert_redirects
@@ -13,9 +13,8 @@ from stagecraft.apps.dashboards.tests.factories.factories import(
     DashboardFactory, DepartmentFactory, ModuleTypeFactory, ModuleFactory,
     LinkFactory
 )
-from stagecraft.apps.datasets.tests.factories import(
-    DataGroupFactory, DataTypeFactory, DataSetFactory
-)
+from stagecraft.apps.datasets.tests.factories import DataSetFactory
+
 from stagecraft.apps.dashboards.models.dashboard import (
     Dashboard)
 from stagecraft.apps.dashboards.models.module import Module
@@ -24,7 +23,6 @@ from stagecraft.libs.authorization.tests.test_http import (
     with_govuk_signon)
 from stagecraft.libs.views.utils import to_json
 from stagecraft.libs.views.utils import JsonEncoder
-from nose.tools import nottest
 
 
 class DashboardViewsListTestCase(TestCase):
@@ -713,7 +711,7 @@ class DashboardViewsCreateTestCase(TestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION='Bearer correct-token')
 
-        assert_that(resp.status_code, equal_to(400))
+        assert_that(resp.status_code, equal_to(404))
         assert_that(Dashboard.objects.count(), equal_to(0))
 
     @with_govuk_signon(permissions=['dashboard'])

--- a/stagecraft/apps/dashboards/tests/views/test_dashboard.py
+++ b/stagecraft/apps/dashboards/tests/views/test_dashboard.py
@@ -859,5 +859,6 @@ class DashboardViewsCreateTestCase(TestCase):
         expected_message = "validation errors:\n" \
                            "strapline: Value u'Invalid' is not a valid choice."
 
+        response_dict = json.loads(resp.content)
         assert_that(resp.status_code, equal_to(400))
-        assert_that(resp.content, equal_to(expected_message))
+        assert_that(response_dict['message'], equal_to(expected_message))

--- a/stagecraft/apps/datasets/tests/views/test_data_set.py
+++ b/stagecraft/apps/datasets/tests/views/test_data_set.py
@@ -562,9 +562,12 @@ class DataSetsViewsTestCase(TestCase):
             data=json.dumps(data_set),
             HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
             content_type='application/json')
+
+        response_dict = json.loads(resp.content)
+
         assert_equal(resp.status_code, 400)
         assert_equal(
-            resp.content,
+            response_dict['message'],
             "options failed validation: Additional properties are not allowed "
             "(u'name' was unexpected)")
 
@@ -586,9 +589,11 @@ class DataSetsViewsTestCase(TestCase):
             data=json.dumps(data_set),
             HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
             content_type='application/json')
+
+        response_dict = json.loads(resp.content)
         assert_equal(resp.status_code, 400)
         assert_equal(
-            resp.content,
+            response_dict['message'],
             "validation errors:\n__all__: Data set with this "
             "Data group and Data type already exists.")
 
@@ -610,9 +615,11 @@ class DataSetsViewsTestCase(TestCase):
             data=json.dumps(data_set),
             HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
             content_type='application/json')
+
+        response_dict = json.loads(resp.content)
         assert_equal(resp.status_code, 400)
         assert_equal(
-            resp.content,
+            response_dict['message'],
             "validation errors:\n__all__: Data set with this "
             "Data group and Data type already exists.")
 
@@ -633,9 +640,12 @@ class DataSetsViewsTestCase(TestCase):
             data=json.dumps(data_set),
             HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
             content_type='application/json')
+
+        response_dict = json.loads(resp.content)
+
         assert_equal(resp.status_code, 400)
         assert_equal(
-            resp.content,
+            response_dict['message'],
             "options failed validation: 'data_group' is a required property")
 
     def test_post_when_no_type(self):
@@ -655,9 +665,11 @@ class DataSetsViewsTestCase(TestCase):
             data=json.dumps(data_set),
             HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
             content_type='application/json')
+        response_dict = json.loads(resp.content)
+
         assert_equal(resp.status_code, 400)
         assert_equal(
-            resp.content,
+            response_dict['message'],
             "options failed validation: 'data_type' is a required property")
 
     def test_post_when_non_existant_group(self):

--- a/stagecraft/apps/datasets/views/data_set.py
+++ b/stagecraft/apps/datasets/views/data_set.py
@@ -113,6 +113,7 @@ class DataSetView(ResourceView):
         return super(DataSetView, self).post(request, **kwargs)
 
     def update_model(self, model, model_json, request, parent):
+        logger.setLevel('ERROR')
         try:
             data_group = DataGroup.objects.get(name=model_json['data_group'])
             data_type = DataType.objects.get(name=model_json['data_type'])
@@ -123,11 +124,11 @@ class DataSetView(ResourceView):
         except DataGroup.DoesNotExist:
             message = "No data group with name '{}' found".format(
                 model_json['data_group'])
-            return create_http_error(400, message, request)
+            return create_http_error(400, message, request, logger=logger)
         except DataType.DoesNotExist:
             message = "No data type with name '{}' found".format(
                 model_json['data_type'])
-            return create_http_error(400, message, request)
+            return create_http_error(400, message, request, logger=logger)
 
     @staticmethod
     def serialize(model):

--- a/stagecraft/apps/organisation/views.py
+++ b/stagecraft/apps/organisation/views.py
@@ -1,11 +1,10 @@
-from django.http import HttpResponse
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
 
-from stagecraft.libs.authorization.http import permission_required
 from stagecraft.libs.validation.validation import is_uuid
 from stagecraft.libs.views.resource import ResourceView
 from .models import Node, NodeType
+from stagecraft.libs.views.utils import create_http_error
 
 
 class NodeTypeView(ResourceView):
@@ -101,7 +100,7 @@ class NodeView(ResourceView):
         try:
             node_type = NodeType.objects.get(id=model_json['type_id'])
         except NodeType.DoesNotExist:
-            return HttpResponse('no NodeType found', status=400)
+            return create_http_error(400, 'no NodeType found', request)
 
         model.name = model_json['name']
         model.slug = model_json.get('slug', None)
@@ -112,12 +111,13 @@ class NodeView(ResourceView):
         if 'parent_id' in model_json:
             parent_id = model_json['parent_id']
             if not is_uuid(parent_id):
-                return HttpResponse('parent_id has to be a uuid', status=400)
+                return create_http_error(400, 'parent_id has to be a uuid',
+                                         request)
 
             try:
                 parent_node = Node.objects.get(id=parent_id)
             except Node.DoesNotExist:
-                return HttpResponse('parent not found', status=400)
+                return create_http_error(400, 'parent not found', request)
 
             model.parents.add(parent_node)
 

--- a/stagecraft/apps/transforms/views.py
+++ b/stagecraft/apps/transforms/views.py
@@ -13,6 +13,7 @@ from stagecraft.apps.datasets.models import DataGroup, DataType
 from .models import Transform, TransformType
 
 from stagecraft.libs.views.resource import ResourceView
+from stagecraft.libs.views.utils import create_http_error
 
 
 def resolve_data_reference(reference):
@@ -152,22 +153,25 @@ class TransformView(ResourceView):
             transform_type = TransformType.objects.get(
                 id=model_json['type_id'])
         except TransformType.DoesNotExist:
-            return HttpResponse('transform type was not found', status=400)
+            return create_http_error(400, 'transform type was not found',
+                                     request)
 
         (input_group, input_type) = resolve_data_reference(model_json['input'])
 
         if input_type is None:
-            return HttpResponse(
+            return create_http_error(
+                400,
                 'input requires at least a data-type (that exists)',
-                status=400)
+                request)
 
         (output_group, output_type) = \
             resolve_data_reference(model_json['output'])
 
         if output_type is None:
-            return HttpResponse(
+            return create_http_error(
+                400,
                 'output requires at least a data-type (that exists)',
-                status=400)
+                request)
 
         model.type = transform_type
         model.input_group = input_group

--- a/stagecraft/libs/authorization/http.py
+++ b/stagecraft/libs/authorization/http.py
@@ -4,9 +4,8 @@ import requests
 
 from stagecraft.apps.datasets.models import OAuthUser
 from stagecraft.libs.validation.validation import extract_bearer_token
-from stagecraft.libs.views.utils import create_error
+from stagecraft.libs.views.utils import create_http_error
 from django.conf import settings
-from django.http import (HttpResponseForbidden, HttpResponse, HttpRequest)
 from django_statsd.clients import statsd
 
 audit_logger = logging.getLogger('stagecraft.audit')
@@ -72,23 +71,14 @@ def check_permission(access_token, permission_requested, anon_allowed=True):
 
 
 def unauthorized(request, message):
-    doc = {
-        'status': 'error',
-        'message': 'Unauthorized: {}'.format(message),
-    }
-    doc["errors"] = [create_error(request, 401, detail=doc["message"])]
-    response = HttpResponse(to_json(doc), status=401)
+    response = create_http_error(
+        401, 'Unauthorized: {}'.format(message), request)
     response['WWW-Authenticate'] = 'Bearer'
     return response
 
 
 def forbidden(request, message):
-    doc = {
-        'status': 'error',
-        'message': 'Forbidden: {}'.format(message),
-    }
-    doc["errors"] = [create_error(request, 403, detail=doc["message"])]
-    return HttpResponseForbidden(to_json(doc))
+    return create_http_error(403, 'Forbidden: {}'.format(message), request)
 
 
 def authorize(request, permission, anon_allowed=True):

--- a/stagecraft/libs/authorization/tests/test_http.py
+++ b/stagecraft/libs/authorization/tests/test_http.py
@@ -177,8 +177,29 @@ class CheckPermissionTestCase(TestCase):
 
             assert_that(has_permission, equal_to(False))
 
-    # def test_anon_user_if_no_token(self):
-    #     assert_that(True, is_(False))
+    def test_anon_user_if_no_token(self):
+        settings.USE_DEVELOPMENT_USERS = False
+
+        (user, has_permission) = check_permission(None, None, True)
+
+        assert_that(has_permission, equal_to(True))
+        assert_that(user.get('name'), equal_to('Anonymous'))
+
+    def test_no_user_if_no_token_and_anon_user_not_allowed(self):
+        settings.USE_DEVELOPMENT_USERS = False
+
+        (user, has_permission) = check_permission(None, None, False)
+
+        assert_that(has_permission, equal_to(False))
+        assert_that(user, is_(None))
+
+    def test_anon_user_if_permission_requested(self):
+        settings.USE_DEVELOPMENT_USERS = False
+
+        (user, has_permission) = check_permission(None, 'permission', True)
+
+        assert_that(has_permission, equal_to(False))
+        assert_that(user.get('name'), equal_to('Anonymous'))
 
 
 class AuthorizeTestCase(TestCase):

--- a/stagecraft/libs/views/tests/test_resource.py
+++ b/stagecraft/libs/views/tests/test_resource.py
@@ -80,7 +80,7 @@ class TestResourceView(ResourceView):
         try:
             node_type = NodeType.objects.get(id=model_json['type_id'])
         except NodeType.DoesNotExist:
-            return HttpResponse('no NodeType found', status=400)
+            return create_http_error(400, 'no NodeType found', request)
 
         model.name = model_json['name']
         model.slug = model_json.get('slug', None)

--- a/stagecraft/libs/views/tests/test_resource.py
+++ b/stagecraft/libs/views/tests/test_resource.py
@@ -1,14 +1,10 @@
 import json
-
-from django.test.client import RequestFactory
-from mock import Mock
-from hamcrest import (
-    assert_that, is_, calling, raises, is_not,
-    instance_of, starts_with, has_key, equal_to,
-    has_entry,
-    contains)
 from unittest import TestCase
 
+from hamcrest import (
+    assert_that, is_, calling, raises, is_not,
+    instance_of, starts_with, has_key, has_entry,
+    contains, equal_to)
 from django.http import HttpRequest, HttpResponse
 from jsonschema import FormatError
 
@@ -16,11 +12,10 @@ from stagecraft.apps.organisation.models import Node, NodeType
 from stagecraft.apps.organisation.tests.factories import (
     NodeFactory, NodeTypeFactory
 )
-
 from ..resource import (
     FORMAT_CHECKER, ResourceView, resource_re_string,
-    UUID_RE_STRING
-)
+    UUID_RE_STRING)
+from stagecraft.libs.views.utils import create_http_error
 
 
 class FormatCheckerTestCase(TestCase):
@@ -471,3 +466,16 @@ class ResourceViewTestCase(TestCase):
             'sub_resource': 'child',
         }, body=json.dumps({}))
         assert_that(status_code, is_(400))
+
+    def test_create_http_error(self):
+        status = 400
+        message = "Detail for 400 Bad Request"
+        request = HttpRequest()
+
+        error = create_http_error(status, message, request)
+
+        err = json.loads(error.content)
+
+        assert_that(error.status_code, equal_to(400))
+        assert_that(err["errors"][0]["detail"],
+                    equal_to("Detail for 400 Bad Request"))

--- a/stagecraft/libs/views/utils.py
+++ b/stagecraft/libs/views/utils.py
@@ -3,7 +3,7 @@ import json
 from django.utils.cache import patch_response_headers
 from functools import wraps
 from uuid import UUID
-from django.http import HttpResponseBadRequest
+from django.http import HttpResponseBadRequest, HttpResponse
 
 
 class JsonEncoder(json.JSONEncoder):
@@ -56,10 +56,28 @@ def create_error(request, status, code='', title='', detail=''):
     "detail" - A human-readable explanation specific to this
                occurrence of the problem.
     """
+    id = ''
+    if request:
+        id = request.META.get('HTTP_REQUEST_ID', '')
+
     return {
-        'id': request.META.get('HTTP_REQUEST_ID', ''),
+        'id': id,
         'status': str(status),
         'code': code,
         'title': title,
         'detail': detail,
     }
+
+
+def create_http_error(status, message, request, code='', title=''):
+    error = {
+        'status': 'error',
+        'message': message,
+        'errors': [create_error(request,
+                                status,
+                                code=code,
+                                title=title,
+                                detail=message)],
+    }
+
+    return HttpResponse(to_json(error), status=status)

--- a/stagecraft/libs/views/utils.py
+++ b/stagecraft/libs/views/utils.py
@@ -3,7 +3,7 @@ import json
 from django.utils.cache import patch_response_headers
 from functools import wraps
 from uuid import UUID
-from django.http import HttpResponseBadRequest, HttpResponse
+from django.http import HttpResponse
 
 
 class JsonEncoder(json.JSONEncoder):
@@ -29,18 +29,6 @@ def long_cache(a_view):
 
 def to_json(what):
     return json.dumps(what, indent=1, cls=JsonEncoder)
-
-
-def build_400(logger, request, message):
-    error = {'status': 'error',
-             'message': message}
-    logger.error(error)
-
-    error["errors"] = [
-        create_error(request, 400, detail=error['message'])
-    ]
-
-    return HttpResponseBadRequest(to_json(error))
 
 
 def create_error(request, status, code='', title='', detail=''):
@@ -69,7 +57,8 @@ def create_error(request, status, code='', title='', detail=''):
     }
 
 
-def create_http_error(status, message, request, code='', title=''):
+def create_http_error(status, message, request, code='', title='',
+                      logger=None):
     error = {
         'status': 'error',
         'message': message,
@@ -79,5 +68,7 @@ def create_http_error(status, message, request, code='', title=''):
                                 title=title,
                                 detail=message)],
     }
+    if logger:
+        logger.error(error)
 
     return HttpResponse(to_json(error), status=status)


### PR DESCRIPTION
Remaining bits from the ResourceView migration.

All responses should now be JSON.