### PR TITLE
Update stagecraft config to work with govuk assets

### DIFF
--- a/stagecraft/settings/common.py
+++ b/stagecraft/settings/common.py
@@ -115,7 +115,7 @@ NOSE_ARGS = ['-s', '--exclude-dir=stagecraft/settings']
 # https://docs.djangoproject.com/en/1.6/howto/static-files/
 
 STATIC_URL = '/static/'
-STATIC_ROOT = abspath(pjoin(BASE_DIR, 'assets'))
+STATIC_ROOT = abspath(pjoin(BASE_DIR, 'public', 'stagecraft'))
 
 DOGSLOW_LOG_TO_FILE = False
 DOGSLOW_TIMER = 1


### PR DESCRIPTION
The govuk assets serving relies on assets being in the public subdirectory and this setting updates Django to create the assets there.