### PR TITLE
Feature/django 1.8.x

### DIFF
--- a/requirements/_common.txt
+++ b/requirements/_common.txt
@@ -1,10 +1,9 @@
 # requirements/common.txt: Used on *all* environments.
 
-django==1.7.8
+django==1.8.2
 django-dbarray==0.2
 django-mptt==0.6.1
-django-reversion==1.8.0
-django-uuidfield==0.5.0
+django-reversion==1.8.6
 jsonfield==0.9.22
 requests==2.2.1
 logstash_formatter==0.5.7
@@ -12,7 +11,7 @@ logstash_formatter==0.5.7
 jsonschema==2.3.0
 
 # psycopg2 requires the libpq-dev package
-psycopg2==2.5.2
+psycopg2==2.5.4
 
 # For performing data operations that require speaking to backdrop
 performanceplatform-client==0.2.4

--- a/requirements/_common.txt
+++ b/requirements/_common.txt
@@ -3,7 +3,7 @@
 django==1.8.2
 django-dbarray==0.2
 django-mptt==0.6.1
-django-reversion==1.8.6
+django-reversion==1.8.7
 jsonfield==0.9.22
 requests==2.2.1
 logstash_formatter==0.5.7

--- a/requirements/_testing.txt
+++ b/requirements/_testing.txt
@@ -5,7 +5,7 @@ nose
 nose-exclude==0.2.0
 mock>=1.0
 
-django-nose==1.2
+django-nose==1.4
 pep8==1.5.7
 coverage==3.6
 PyHamcrest==1.8.0

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -40,7 +40,7 @@ find $basedir/stagecraft -iname '*.pyc' -exec rm {} \+
 find $basedir/stagecraft -iname '__pycache__' -exec rmdir {} \+
 
 # probably going to need to install dependencies
-pip install -r requirements/ci.txt --use-mirrors
+pip install -r requirements/ci.txt
 
 if [ -z "$NO_AUTOPEP8" ]; then
   autopep8 -i -r stagecraft --exclude '00*.py'

--- a/stagecraft/apps/dashboards/migrations/0001_initial.py
+++ b/stagecraft/apps/dashboards/migrations/0001_initial.py
@@ -4,8 +4,8 @@ from __future__ import unicode_literals
 from django.db import models, migrations
 import dbarray.fields
 import jsonfield.fields
-import uuidfield.fields
 import django.core.validators
+import uuid
 
 
 class Migration(migrations.Migration):
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Dashboard',
             fields=[
-                ('id', uuidfield.fields.UUIDField(primary_key=True, auto=True, serialize=False, hyphenate=True)),
+                ('id', models.UUIDField(default=uuid.uuid4, serialize=False, editable=False, primary_key=True)),
                 ('slug', models.CharField(unique=True, max_length=90, validators=[django.core.validators.RegexValidator('^[-a-z0-9]+$', message='Slug can only contain lower case letters, numbers or hyphens')])),
                 ('dashboard_type', models.CharField(default='transaction', max_length=30, choices=[('transaction', 'transaction'), ('high-volume-transaction', 'high-volume-transaction'), ('service-group', 'service-group'), ('agency', 'agency'), ('department', 'department'), ('content', 'content'), ('other', 'other')])),
                 ('page_type', models.CharField(default='dashboard', max_length=80)),
@@ -40,27 +40,21 @@ class Migration(migrations.Migration):
                 ('service_cache', models.ForeignKey(related_name='dashboards_owned_by_service', blank=True, to='organisation.Node', null=True)),
                 ('transaction_cache', models.ForeignKey(related_name='dashboards_owned_by_transaction', blank=True, to='organisation.Node', null=True)),
             ],
-            options={
-            },
-            bases=(models.Model,),
         ),
         migrations.CreateModel(
             name='Link',
             fields=[
-                ('id', uuidfield.fields.UUIDField(primary_key=True, auto=True, serialize=False, hyphenate=True)),
+                ('id', models.UUIDField(default=uuid.uuid4, serialize=False, editable=False, primary_key=True)),
                 ('title', models.CharField(max_length=100)),
                 ('url', models.URLField()),
                 ('link_type', models.CharField(max_length=20, choices=[('transaction', 'transaction'), ('other', 'other')])),
                 ('dashboard', models.ForeignKey(to='dashboards.Dashboard')),
             ],
-            options={
-            },
-            bases=(models.Model,),
         ),
         migrations.CreateModel(
             name='Module',
             fields=[
-                ('id', uuidfield.fields.UUIDField(primary_key=True, auto=True, serialize=False, hyphenate=True)),
+                ('id', models.UUIDField(default=uuid.uuid4, serialize=False, editable=False, primary_key=True)),
                 ('slug', models.CharField(max_length=60, validators=[django.core.validators.RegexValidator('^[-a-z0-9]+$', message='Slug can only contain lower case letters, numbers or hyphens')])),
                 ('title', models.CharField(max_length=60)),
                 ('description', models.CharField(max_length=200, blank=True)),
@@ -72,26 +66,19 @@ class Migration(migrations.Migration):
                 ('data_set', models.ForeignKey(blank=True, to='datasets.DataSet', null=True)),
                 ('parent', models.ForeignKey(blank=True, to='dashboards.Module', null=True)),
             ],
-            options={
-            },
-            bases=(models.Model,),
         ),
         migrations.CreateModel(
             name='ModuleType',
             fields=[
-                ('id', uuidfield.fields.UUIDField(primary_key=True, auto=True, serialize=False, hyphenate=True)),
+                ('id', models.UUIDField(default=uuid.uuid4, serialize=False, editable=False, primary_key=True)),
                 ('name', models.CharField(unique=True, max_length=25, validators=[django.core.validators.RegexValidator('^[a-z_]+$', message='Module type name can only contain lowercase letters, numbers or underscores')])),
                 ('schema', jsonfield.fields.JSONField()),
             ],
-            options={
-            },
-            bases=(models.Model,),
         ),
         migrations.AddField(
             model_name='module',
             name='type',
             field=models.ForeignKey(to='dashboards.ModuleType'),
-            preserve_default=True,
         ),
         migrations.AlterUniqueTogether(
             name='module',

--- a/stagecraft/apps/dashboards/migrations/0002_auto_20150615_0916.py
+++ b/stagecraft/apps/dashboards/migrations/0002_auto_20150615_0916.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import jsonfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dashboards', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='module',
+            name='options',
+            field=jsonfield.fields.JSONField(default={}, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='moduletype',
+            name='schema',
+            field=jsonfield.fields.JSONField(default={}),
+        ),
+    ]

--- a/stagecraft/apps/dashboards/models/dashboard.py
+++ b/stagecraft/apps/dashboards/models/dashboard.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
+import uuid
 from django.core.validators import RegexValidator
 from django.db import models
-from uuidfield import UUIDField
 
 from stagecraft.apps.organisation.views import NodeView
 
@@ -30,7 +30,7 @@ class DashboardManager(models.Manager):
 class Dashboard(models.Model):
     objects = DashboardManager()
 
-    id = UUIDField(auto=True, primary_key=True, hyphenate=True)
+    id = models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True)
     slug_validator = RegexValidator(
         '^[-a-z0-9]+$',
         message='Slug can only contain lower case letters, numbers or hyphens'
@@ -364,7 +364,7 @@ class Dashboard(models.Model):
 
 
 class Link(models.Model):
-    id = UUIDField(auto=True, primary_key=True, hyphenate=True)
+    id = models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True)
     title = models.CharField(max_length=100)
     url = models.URLField(max_length=200)
     dashboard = models.ForeignKey(Dashboard)

--- a/stagecraft/apps/dashboards/models/dashboard.py
+++ b/stagecraft/apps/dashboards/models/dashboard.py
@@ -250,9 +250,14 @@ class Dashboard(models.Model):
         return modules_or_tabs
 
     def serialize(self):
+        def simple_field(field):
+            return not (field.is_relation or field.one_to_one or (
+                field.many_to_one and field.related_model))
+
         serialized = {}
-        fields = self._meta.get_fields_with_model()
-        field_names = [field.name for field, _ in fields]
+        fields = self._meta.get_fields()
+        field_names = [field.name for field in fields
+                       if simple_field(field)]
 
         for field in field_names:
             if not (field.startswith('_') or field.endswith('_cache')):

--- a/stagecraft/apps/dashboards/models/module.py
+++ b/stagecraft/apps/dashboards/models/module.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 import copy
 import jsonschema
+import uuid
 from jsonschema import Draft3Validator, SchemaError
 
 from django.core.validators import RegexValidator
@@ -8,7 +9,6 @@ from django.db import models
 
 from dbarray import TextArrayField
 from jsonfield import JSONField
-from uuidfield import UUIDField
 
 from stagecraft.apps.datasets.models import DataSet
 
@@ -24,7 +24,7 @@ class ModuleManager(models.Manager):
 
 
 class ModuleType(models.Model):
-    id = UUIDField(auto=True, primary_key=True, hyphenate=True)
+    id = models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True)
 
     name_validator = RegexValidator(
         '^[a-z_]+$',
@@ -62,7 +62,7 @@ class ModuleType(models.Model):
 
 
 class Module(models.Model):
-    id = UUIDField(auto=True, primary_key=True, hyphenate=True)
+    id = models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True)
     type = models.ForeignKey(ModuleType)
     dashboard = models.ForeignKey(Dashboard)
     data_set = models.ForeignKey(DataSet, null=True, blank=True)

--- a/stagecraft/apps/dashboards/models/module.py
+++ b/stagecraft/apps/dashboards/models/module.py
@@ -39,7 +39,7 @@ class ModuleType(models.Model):
         ]
     )
 
-    schema = JSONField()
+    schema = JSONField(default={})
 
     class Meta:
         app_label = 'dashboards'
@@ -83,7 +83,7 @@ class Module(models.Model):
     description = models.CharField(max_length=200, blank=True)
     info = TextArrayField(blank=True)
 
-    options = JSONField(blank=True)
+    options = JSONField(blank=True, default={})
     query_parameters = JSONField(null=True, blank=True)
 
     order = models.IntegerField()

--- a/stagecraft/apps/datasets/admin/data_group.py
+++ b/stagecraft/apps/datasets/admin/data_group.py
@@ -18,19 +18,10 @@ class DataSetInline(admin.StackedInline):
 
 class DataGroupAdmin(reversion.VersionAdmin):
     search_fields = ['name']
-    list_display = ('name', 'number_of_datasets',)
+    list_display = ('name',)
     inlines = [
         DataSetInline
     ]
 
-    def queryset(self, request):
-        qs = super(DataGroupAdmin, self).queryset(request)
-        qs = qs.annotate(models.Count('dataset'))
-        return qs
-
-    def number_of_datasets(self, obj):
-        return obj.dataset__count
-
-    number_of_datasets.admin_order_field = 'dataset__count'
 
 admin.site.register(DataGroup, DataGroupAdmin)

--- a/stagecraft/apps/datasets/admin/data_type.py
+++ b/stagecraft/apps/datasets/admin/data_type.py
@@ -18,19 +18,10 @@ class DataSetInline(admin.StackedInline):
 
 class DataTypeAdmin(reversion.VersionAdmin):
     search_fields = ['name']
-    list_display = ('name', 'number_of_datasets',)
+    list_display = ('name',)
     inlines = [
         DataSetInline
     ]
 
-    def queryset(self, request):
-        qs = super(DataTypeAdmin, self).queryset(request)
-        qs = qs.annotate(models.Count('dataset'))
-        return qs
-
-    def number_of_datasets(self, obj):
-        return obj.dataset__count
-
-    number_of_datasets.admin_order_field = 'dataset__count'
 
 admin.site.register(DataType, DataTypeAdmin)

--- a/stagecraft/apps/datasets/migrations/0002_auto_20150609_1959.py
+++ b/stagecraft/apps/datasets/migrations/0002_auto_20150609_1959.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('datasets', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='oauthuser',
+            name='email',
+            field=models.EmailField(max_length=254),
+        ),
+    ]

--- a/stagecraft/apps/organisation/migrations/0001_initial.py
+++ b/stagecraft/apps/organisation/migrations/0001_initial.py
@@ -2,8 +2,8 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-import uuidfield.fields
 import django.core.validators
+import uuid
 
 
 class Migration(migrations.Migration):
@@ -15,31 +15,24 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Node',
             fields=[
-                ('id', uuidfield.fields.UUIDField(primary_key=True, auto=True, serialize=False, hyphenate=True)),
+                ('id', models.UUIDField(default=uuid.uuid4, serialize=False, editable=False, primary_key=True)),
                 ('name', models.CharField(max_length=256)),
                 ('abbreviation', models.CharField(max_length=50, null=True, blank=True)),
-                ('slug', models.CharField(default='', max_length=150, validators=[django.core.validators.RegexValidator(b'^[-a-z0-9]+$', message='Slug can only contain lower case letters, numbers or hyphens')])),
+                ('slug', models.CharField(default=b'', max_length=150, validators=[django.core.validators.RegexValidator(b'^[-a-z0-9]+$', message=b'Slug can only contain lower case letters, numbers or hyphens')])),
                 ('parents', models.ManyToManyField(to='organisation.Node')),
             ],
-            options={
-            },
-            bases=(models.Model,),
         ),
         migrations.CreateModel(
             name='NodeType',
             fields=[
-                ('id', uuidfield.fields.UUIDField(primary_key=True, auto=True, serialize=False, hyphenate=True)),
+                ('id', models.UUIDField(default=uuid.uuid4, serialize=False, editable=False, primary_key=True)),
                 ('name', models.CharField(unique=True, max_length=256)),
             ],
-            options={
-            },
-            bases=(models.Model,),
         ),
         migrations.AddField(
             model_name='node',
             name='typeOf',
             field=models.ForeignKey(to='organisation.NodeType'),
-            preserve_default=True,
         ),
         migrations.AlterUniqueTogether(
             name='node',

--- a/stagecraft/apps/organisation/models.py
+++ b/stagecraft/apps/organisation/models.py
@@ -1,6 +1,6 @@
+import uuid
 from django.core.validators import RegexValidator
 from django.db import models
-from uuidfield import UUIDField
 
 
 class NodeManager(models.Manager):
@@ -48,7 +48,7 @@ class NodeManager(models.Manager):
 
 
 class NodeType(models.Model):
-    id = UUIDField(auto=True, primary_key=True, hyphenate=True)
+    id = models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True)
     name = models.CharField(max_length=256, unique=True)
 
     def __str__(self):
@@ -62,7 +62,7 @@ class Node(models.Model):
 
     objects = NodeManager()
 
-    id = UUIDField(auto=True, primary_key=True, hyphenate=True)
+    id = models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True)
     name = models.CharField(max_length=256)
     abbreviation = models.CharField(
         max_length=50,

--- a/stagecraft/apps/transforms/migrations/0001_initial.py
+++ b/stagecraft/apps/transforms/migrations/0001_initial.py
@@ -3,8 +3,8 @@ from __future__ import unicode_literals
 
 from django.db import models, migrations
 import jsonfield.fields
-import uuidfield.fields
 import django.core.validators
+import uuid
 
 
 class Migration(migrations.Migration):
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Transform',
             fields=[
-                ('id', uuidfield.fields.UUIDField(primary_key=True, auto=True, serialize=False, hyphenate=True)),
+                ('id', models.UUIDField(default=uuid.uuid4, serialize=False, editable=False, primary_key=True)),
                 ('query_parameters', jsonfield.fields.JSONField(default={}, blank=True)),
                 ('options', jsonfield.fields.JSONField(default={}, blank=True)),
                 ('input_group', models.ForeignKey(related_name='+', blank=True, to='datasets.DataGroup', null=True)),
@@ -25,26 +25,19 @@ class Migration(migrations.Migration):
                 ('output_group', models.ForeignKey(related_name='+', blank=True, to='datasets.DataGroup', null=True)),
                 ('output_type', models.ForeignKey(related_name='+', to='datasets.DataType')),
             ],
-            options={
-            },
-            bases=(models.Model,),
         ),
         migrations.CreateModel(
             name='TransformType',
             fields=[
-                ('id', uuidfield.fields.UUIDField(primary_key=True, auto=True, serialize=False, hyphenate=True)),
+                ('id', models.UUIDField(default=uuid.uuid4, serialize=False, editable=False, primary_key=True)),
                 ('name', models.CharField(unique=True, max_length=25)),
                 ('schema', jsonfield.fields.JSONField(default={}, blank=True)),
                 ('function', models.CharField(unique=True, max_length=200, validators=[django.core.validators.RegexValidator(b'^[a-z_\\.]+$', message=b'Transform function has to consist of lowercaseletters, underscores or dots')])),
             ],
-            options={
-            },
-            bases=(models.Model,),
         ),
         migrations.AddField(
             model_name='transform',
             name='type',
             field=models.ForeignKey(to='transforms.TransformType'),
-            preserve_default=True,
         ),
     ]

--- a/stagecraft/apps/transforms/models.py
+++ b/stagecraft/apps/transforms/models.py
@@ -1,12 +1,12 @@
 import logging
 import jsonschema
+import uuid
 from jsonschema import Draft3Validator, SchemaError, ValidationError
 
 from django.core.validators import RegexValidator
 from django.db import models
 
 from jsonfield import JSONField
-from uuidfield import UUIDField
 
 from stagecraft.apps.datasets.models import DataGroup, DataType
 from stagecraft.apps.dashboards.models.module import query_param_schema
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class TransformType(models.Model):
-    id = UUIDField(auto=True, primary_key=True, hyphenate=True)
+    id = models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True)
     name = models.CharField(
         max_length=25,
         unique=True,
@@ -48,7 +48,7 @@ class TransformType(models.Model):
 
 
 class Transform(models.Model):
-    id = UUIDField(auto=True, primary_key=True, hyphenate=True)
+    id = models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True)
     type = models.ForeignKey(TransformType)
 
     input_group = models.ForeignKey(

--- a/stagecraft/apps/users/admin.py
+++ b/stagecraft/apps/users/admin.py
@@ -14,19 +14,9 @@ class DataSetInline(admin.StackedInline):
 
 class UserAdmin(reversion.VersionAdmin):
     search_fields = ['email']
-    list_display = ('email', 'number_of_datasets_user_has_access_to',)
+    list_display = ('email',)
     list_per_page = 30
     filter_horizontal = ('data_sets',)
-
-    def queryset(self, request):
-        return User.objects.annotate(
-            dataset_count=models.Count('data_sets')
-        )
-
-    def number_of_datasets_user_has_access_to(self, obj):
-        return obj.dataset_count
-
-    number_of_datasets_user_has_access_to.admin_order_field = 'dataset_count'
 
 
 admin.site.register(User, UserAdmin)

--- a/stagecraft/libs/mass_update/test_data_set_mass_update.py
+++ b/stagecraft/libs/mass_update/test_data_set_mass_update.py
@@ -31,6 +31,10 @@ class TestDataSetMassUpdate(TestCase):
             bearer_token="999999",
             data_type=cls.data_type2)
 
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
     def test_update_bearer_token_by_date_type(self):
 
         new_bearer_token = "ghi789"


### PR DESCRIPTION
The django_migrations table needs to be updated with an entry for reversion before this PR is deployed in each environment.

The index for date_created on table reversion_revision has been created in all environments.