### PR TITLE
Change check permissions for lists of permissions

### DIFF
--- a/stagecraft/apps/dashboards/views/dashboard.py
+++ b/stagecraft/apps/dashboards/views/dashboard.py
@@ -176,8 +176,8 @@ class DashboardView(ResourceView):
 
     permissions = {
         'get': None,
-        'post': 'dashboard',
-        'put': 'dashboard',
+        'post': ['dashboard'],
+        'put': ['dashboard'],
     }
 
     @method_decorator(never_cache)

--- a/stagecraft/apps/dashboards/views/module.py
+++ b/stagecraft/apps/dashboards/views/module.py
@@ -174,8 +174,8 @@ class ModuleView(ResourceView):
 
     permissions = {
         'get': None,
-        'post': 'dashboard',
-        'put': 'dashboard',
+        'post': ['dashboard'],
+        'put': ['dashboard'],
     }
 
     def list(self, request, **kwargs):
@@ -281,8 +281,8 @@ class ModuleTypeView(ResourceView):
 
     permissions = {
         'get': None,
-        'post': 'dashboard',
-        'put': 'dashboard',
+        'post': ['dashboard'],
+        'put': ['dashboard'],
     }
 
     @method_decorator(never_cache)

--- a/stagecraft/apps/datasets/views/auth.py
+++ b/stagecraft/apps/datasets/views/auth.py
@@ -9,7 +9,7 @@ from stagecraft.libs.authorization.http import permission_required
 
 @csrf_exempt
 @require_http_methods(['POST', 'PUT'])
-@permission_required('user_update_permission')
+@permission_required(['user_update_permission'])
 @never_cache
 def invalidate(user, request, uid):
     OAuthUser.objects.purge_user(uid)

--- a/stagecraft/apps/datasets/views/data_group.py
+++ b/stagecraft/apps/datasets/views/data_group.py
@@ -16,9 +16,9 @@ class DataGroupView(ResourceView):
     }
 
     permissions = {
-        'get': 'signin',
-        'post': 'signin',
-        'put': 'signin',
+        'get': ['signin'],
+        'post': ['signin'],
+        'put': ['signin'],
     }
 
     @method_decorator(never_cache)

--- a/stagecraft/apps/datasets/views/data_set.py
+++ b/stagecraft/apps/datasets/views/data_set.py
@@ -86,9 +86,9 @@ class DataSetView(ResourceView):
     }
 
     permissions = {
-        'get': 'signin',
-        'post': 'signin',
-        'put': 'signin',
+        'get': ['signin'],
+        'post': ['signin'],
+        'put': ['signin'],
     }
 
     def list(self, request, **kwargs):
@@ -160,7 +160,7 @@ def transform(request, name):
         content_type='application/json')
 
 
-@permission_required('dashboard')
+@permission_required(['dashboard'])
 @never_cache
 def dashboard(user, request, name):
     try:
@@ -176,7 +176,7 @@ def dashboard(user, request, name):
     return HttpResponse(json_str, content_type='application/json')
 
 
-@permission_required('admin')
+@permission_required(['admin'])
 @long_cache
 @vary_on_headers('Authorization')
 def users(user, request, dataset_name):

--- a/stagecraft/apps/organisation/views.py
+++ b/stagecraft/apps/organisation/views.py
@@ -27,8 +27,8 @@ class NodeTypeView(ResourceView):
 
     permissions = {
         'get': None,
-        'post': 'organisation',
-        'put': 'organisation',
+        'post': ['organisation'],
+        'put': ['organisation'],
     }
 
     @method_decorator(never_cache)
@@ -81,8 +81,8 @@ class NodeView(ResourceView):
 
     permissions = {
         'get': None,
-        'post': 'organisation',
-        'put': 'organisation',
+        'post': ['organisation'],
+        'put': ['organisation'],
     }
 
     def list(self, request, **kwargs):

--- a/stagecraft/apps/transforms/views.py
+++ b/stagecraft/apps/transforms/views.py
@@ -60,8 +60,8 @@ class TransformTypeView(ResourceView):
 
     permissions = {
         'get': None,
-        'post': 'transforms',
-        'put': 'transforms',
+        'post': ['transforms'],
+        'put': ['transforms'],
     }
 
     @method_decorator(never_cache)
@@ -140,8 +140,8 @@ class TransformView(ResourceView):
 
     permissions = {
         'get': None,
-        'post': 'transforms',
-        'put': 'transforms',
+        'post': ['transforms'],
+        'put': ['transforms'],
     }
 
     @method_decorator(never_cache)

--- a/stagecraft/apps/users/views.py
+++ b/stagecraft/apps/users/views.py
@@ -41,9 +41,9 @@ class UserView(ResourceView):
     }
 
     permissions = {
-        'get': 'user',
-        'post': 'user',
-        'put': 'user',
+        'get': ['user'],
+        'post': ['user'],
+        'put': ['user'],
     }
 
     @never_cache

--- a/stagecraft/libs/authorization/http.py
+++ b/stagecraft/libs/authorization/http.py
@@ -13,6 +13,15 @@ audit_logger = logging.getLogger('stagecraft.audit')
 
 @statsd.timer('get_user.both')
 def _get_user(access_token, anon_allowed):
+    """
+    Attempts to find a user (using the access token ) in
+    either Stagecraft's OAuthUser table or, and as fallback, via a request to
+    GovUK's Signon API.
+
+    Args:
+        access_token: access token from request
+        anon_allowed: whether to allow anonymous users
+    """
     user = None
     if access_token is not None:
 

--- a/stagecraft/libs/authorization/http.py
+++ b/stagecraft/libs/authorization/http.py
@@ -73,9 +73,16 @@ def _set_user_to_database(access_token, user):
 
 def check_permission(access_token, permission_requested, anon_allowed=True):
     user = _get_user(access_token, anon_allowed)
+    if user is None:
+        return (user, False)
+    if permission_requested is None:
+        permission_requested_set = set()
+    else:
+        permission_requested_set = set(permission_requested)
+    user_permissions = set(user['permissions'])
     has_permission = user is not None and \
         (permission_requested is None or
-         permission_requested in user['permissions'])
+         len(permission_requested_set.intersection(user_permissions)) > 0)
     return (user, has_permission)
 
 

--- a/stagecraft/libs/authorization/tests/test_http.py
+++ b/stagecraft/libs/authorization/tests/test_http.py
@@ -130,6 +130,21 @@ class CheckPermissionTestCase(TestCase):
 
         assert_that(has_permission, equal_to(False))
 
+    def test_user_with_returns_object_and_true_when_permissions_is_list(self):
+        settings.USE_DEVELOPMENT_USERS = False
+
+        OAuthUser.objects.create(access_token='correct-token',
+                                 uid='my-uid',
+                                 email='jon@example.com',
+                                 permissions=['signin'],
+                                 expires_at=datetime.now() + timedelta(days=1))
+
+        (user, has_permission) = check_permission(
+            'correct-token', ['signin', 'bob'])
+
+        assert_that(user['email'], equal_to('jon@example.com'))
+        assert_that(has_permission, equal_to(True))
+
     def test_user_from_database_should_not_be_returned_if_expired(self):
         settings.USE_DEVELOPMENT_USERS = False
         OAuthUser.objects.create(access_token='correct-token-2',


### PR DESCRIPTION
Instead of mapping a single roles to an http method, allow multiple roles
so we can implement finer grained access controls.
Implement role lists