### PR TITLE
Move roles into a centralised location

### DIFF
--- a/stagecraft/apps/dashboards/views/dashboard.py
+++ b/stagecraft/apps/dashboards/views/dashboard.py
@@ -15,6 +15,7 @@ from stagecraft.libs.views.utils import to_json, create_error, \
     create_http_error
 from .module import add_module_to_dashboard, ModuleView
 import time
+from stagecraft.libs.authorization.http import _get_resource_role_permissions
 
 logger = logging.getLogger(__name__)
 
@@ -174,11 +175,7 @@ class DashboardView(ResourceView):
         'slug': 'slug_iexact'
     }
 
-    permissions = {
-        'get': None,
-        'post': ['dashboard'],
-        'put': ['dashboard'],
-    }
+    permissions = _get_resource_role_permissions('Dashboard')
 
     @method_decorator(never_cache)
     def get(self, request, **kwargs):

--- a/stagecraft/apps/dashboards/views/dashboard.py
+++ b/stagecraft/apps/dashboards/views/dashboard.py
@@ -176,8 +176,8 @@ class DashboardView(ResourceView):
 
     permissions = {
         'get': None,
-        'post': 'dashboard',
-        'put': 'dashboard',
+        'post': ['dashboard'],
+        'put': ['dashboard'],
     }
 
     @method_decorator(never_cache)

--- a/stagecraft/apps/dashboards/views/module.py
+++ b/stagecraft/apps/dashboards/views/module.py
@@ -14,6 +14,7 @@ from stagecraft.libs.validation.validation import is_uuid
 
 from ..models import Dashboard, Module, ModuleType
 from stagecraft.libs.views.utils import create_http_error
+from stagecraft.libs.authorization.http import _get_resource_role_permissions
 
 
 def json_response(obj):
@@ -172,11 +173,7 @@ class ModuleView(ResourceView):
         "additionalProperties": False,
     }
 
-    permissions = {
-        'get': None,
-        'post': ['dashboard'],
-        'put': ['dashboard'],
-    }
+    permissions = _get_resource_role_permissions('Module')
 
     def list(self, request, **kwargs):
         query_set = super(ModuleView, self).list(request, **kwargs)
@@ -279,11 +276,7 @@ class ModuleTypeView(ResourceView):
         'name': 'name__iexact'
     }
 
-    permissions = {
-        'get': None,
-        'post': ['dashboard'],
-        'put': ['dashboard'],
-    }
+    permissions = _get_resource_role_permissions('ModuleType')
 
     @method_decorator(never_cache)
     def get(self, request, **kwargs):

--- a/stagecraft/apps/dashboards/views/module.py
+++ b/stagecraft/apps/dashboards/views/module.py
@@ -174,8 +174,8 @@ class ModuleView(ResourceView):
 
     permissions = {
         'get': None,
-        'post': 'dashboard',
-        'put': 'dashboard',
+        'post': ['dashboard'],
+        'put': ['dashboard'],
     }
 
     def list(self, request, **kwargs):
@@ -281,8 +281,8 @@ class ModuleTypeView(ResourceView):
 
     permissions = {
         'get': None,
-        'post': 'dashboard',
-        'put': 'dashboard',
+        'post': ['dashboard'],
+        'put': ['dashboard'],
     }
 
     @method_decorator(never_cache)

--- a/stagecraft/apps/datasets/views/auth.py
+++ b/stagecraft/apps/datasets/views/auth.py
@@ -9,7 +9,7 @@ from stagecraft.libs.authorization.http import permission_required
 
 @csrf_exempt
 @require_http_methods(['POST', 'PUT'])
-@permission_required(['user_update_permission'])
+@permission_required(set(['user_update_permission']))
 @never_cache
 def invalidate(user, request, uid):
     OAuthUser.objects.purge_user(uid)

--- a/stagecraft/apps/datasets/views/auth.py
+++ b/stagecraft/apps/datasets/views/auth.py
@@ -9,7 +9,7 @@ from stagecraft.libs.authorization.http import permission_required
 
 @csrf_exempt
 @require_http_methods(['POST', 'PUT'])
-@permission_required('user_update_permission')
+@permission_required(['user_update_permission'])
 @never_cache
 def invalidate(user, request, uid):
     OAuthUser.objects.purge_user(uid)

--- a/stagecraft/apps/datasets/views/data_group.py
+++ b/stagecraft/apps/datasets/views/data_group.py
@@ -16,9 +16,9 @@ class DataGroupView(ResourceView):
     }
 
     permissions = {
-        'get': 'signin',
-        'post': 'signin',
-        'put': 'signin',
+        'get': ['signin'],
+        'post': ['signin'],
+        'put': ['signin'],
     }
 
     @method_decorator(never_cache)

--- a/stagecraft/apps/datasets/views/data_group.py
+++ b/stagecraft/apps/datasets/views/data_group.py
@@ -3,7 +3,8 @@ from stagecraft.apps.datasets.models import DataGroup
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
 from django.views.decorators.vary import vary_on_headers
-from stagecraft.libs.authorization.http import permission_required
+from stagecraft.libs.authorization.http import (
+    permission_required, _get_resource_role_permissions)
 
 
 class DataGroupView(ResourceView):
@@ -15,11 +16,7 @@ class DataGroupView(ResourceView):
         "name": "name"
     }
 
-    permissions = {
-        'get': ['signin'],
-        'post': ['signin'],
-        'put': ['signin'],
-    }
+    permissions = _get_resource_role_permissions('DataGroup')
 
     @method_decorator(never_cache)
     @method_decorator(vary_on_headers('Authorization'))

--- a/stagecraft/apps/datasets/views/data_set.py
+++ b/stagecraft/apps/datasets/views/data_set.py
@@ -2,7 +2,8 @@ from stagecraft.libs.views.utils import(
     to_json,
     long_cache,
     create_http_error)
-from stagecraft.libs.authorization.http import permission_required
+from stagecraft.libs.authorization.http import (
+    permission_required, _get_resource_role_permissions)
 import logging
 
 from django.http import HttpResponse
@@ -85,11 +86,7 @@ class DataSetView(ResourceView):
         "additionalProperties": False,
     }
 
-    permissions = {
-        'get': ['signin'],
-        'post': ['signin'],
-        'put': ['signin'],
-    }
+    permissions = _get_resource_role_permissions('DataSet')
 
     def list(self, request, **kwargs):
         '''
@@ -160,7 +157,7 @@ def transform(request, name):
         content_type='application/json')
 
 
-@permission_required(['dashboard'])
+@permission_required(set(['dashboard']))
 @never_cache
 def dashboard(user, request, name):
     try:
@@ -176,7 +173,7 @@ def dashboard(user, request, name):
     return HttpResponse(json_str, content_type='application/json')
 
 
-@permission_required(['admin'])
+@permission_required(set(['admin']))
 @long_cache
 @vary_on_headers('Authorization')
 def users(user, request, dataset_name):

--- a/stagecraft/apps/datasets/views/data_set.py
+++ b/stagecraft/apps/datasets/views/data_set.py
@@ -86,9 +86,9 @@ class DataSetView(ResourceView):
     }
 
     permissions = {
-        'get': 'signin',
-        'post': 'signin',
-        'put': 'signin',
+        'get': ['signin'],
+        'post': ['signin'],
+        'put': ['signin'],
     }
 
     def list(self, request, **kwargs):
@@ -160,7 +160,7 @@ def transform(request, name):
         content_type='application/json')
 
 
-@permission_required('dashboard')
+@permission_required(['dashboard'])
 @never_cache
 def dashboard(user, request, name):
     try:
@@ -176,7 +176,7 @@ def dashboard(user, request, name):
     return HttpResponse(json_str, content_type='application/json')
 
 
-@permission_required('admin')
+@permission_required(['admin'])
 @long_cache
 @vary_on_headers('Authorization')
 def users(user, request, dataset_name):

--- a/stagecraft/apps/organisation/views.py
+++ b/stagecraft/apps/organisation/views.py
@@ -27,8 +27,8 @@ class NodeTypeView(ResourceView):
 
     permissions = {
         'get': None,
-        'post': 'organisation',
-        'put': 'organisation',
+        'post': ['organisation'],
+        'put': ['organisation'],
     }
 
     @method_decorator(never_cache)
@@ -81,8 +81,8 @@ class NodeView(ResourceView):
 
     permissions = {
         'get': None,
-        'post': 'organisation',
-        'put': 'organisation',
+        'post': ['organisation'],
+        'put': ['organisation'],
     }
 
     def list(self, request, **kwargs):

--- a/stagecraft/apps/organisation/views.py
+++ b/stagecraft/apps/organisation/views.py
@@ -5,6 +5,7 @@ from stagecraft.libs.validation.validation import is_uuid
 from stagecraft.libs.views.resource import ResourceView
 from .models import Node, NodeType
 from stagecraft.libs.views.utils import create_http_error
+from stagecraft.libs.authorization.http import _get_resource_role_permissions
 
 
 class NodeTypeView(ResourceView):
@@ -25,11 +26,7 @@ class NodeTypeView(ResourceView):
         'name': 'name__iexact',
     }
 
-    permissions = {
-        'get': None,
-        'post': ['organisation'],
-        'put': ['organisation'],
-    }
+    permissions = _get_resource_role_permissions('NodeType')
 
     @method_decorator(never_cache)
     def get(self, request, **kwargs):
@@ -79,11 +76,7 @@ class NodeView(ResourceView):
         'type': 'typeOf__name',
     }
 
-    permissions = {
-        'get': None,
-        'post': ['organisation'],
-        'put': ['organisation'],
-    }
+    permissions = _get_resource_role_permissions('Node')
 
     def list(self, request, **kwargs):
         if 'parent' in kwargs:

--- a/stagecraft/apps/transforms/views.py
+++ b/stagecraft/apps/transforms/views.py
@@ -60,8 +60,8 @@ class TransformTypeView(ResourceView):
 
     permissions = {
         'get': None,
-        'post': 'transforms',
-        'put': 'transforms',
+        'post': ['transforms'],
+        'put': ['transforms'],
     }
 
     @method_decorator(never_cache)
@@ -140,8 +140,8 @@ class TransformView(ResourceView):
 
     permissions = {
         'get': None,
-        'post': 'transforms',
-        'put': 'transforms',
+        'post': ['transforms'],
+        'put': ['transforms'],
     }
 
     @method_decorator(never_cache)

--- a/stagecraft/apps/transforms/views.py
+++ b/stagecraft/apps/transforms/views.py
@@ -6,7 +6,8 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET
 from django.views.decorators.cache import never_cache
 
-from stagecraft.libs.authorization.http import permission_required
+from stagecraft.libs.authorization.http import (
+    permission_required, _get_resource_role_permissions)
 from stagecraft.libs.validation.validation import is_uuid
 
 from stagecraft.apps.datasets.models import DataGroup, DataType
@@ -58,11 +59,7 @@ class TransformTypeView(ResourceView):
         "additionalProperties": False,
     }
 
-    permissions = {
-        'get': None,
-        'post': ['transforms'],
-        'put': ['transforms'],
-    }
+    permissions = _get_resource_role_permissions('TransformType')
 
     @method_decorator(never_cache)
     def get(self, request, **kwargs):
@@ -138,11 +135,7 @@ class TransformView(ResourceView):
         "additionalProperties": False,
     }
 
-    permissions = {
-        'get': None,
-        'post': ['transforms'],
-        'put': ['transforms'],
-    }
+    permissions = _get_resource_role_permissions('Transform')
 
     @method_decorator(never_cache)
     def get(self, request, **kwargs):

--- a/stagecraft/apps/users/views.py
+++ b/stagecraft/apps/users/views.py
@@ -41,9 +41,9 @@ class UserView(ResourceView):
     }
 
     permissions = {
-        'get': 'user',
-        'post': 'user',
-        'put': 'user',
+        'get': ['user'],
+        'post': ['user'],
+        'put': ['user'],
     }
 
     @never_cache

--- a/stagecraft/apps/users/views.py
+++ b/stagecraft/apps/users/views.py
@@ -6,7 +6,8 @@ from django.views.decorators.cache import never_cache
 from django.views.decorators.vary import vary_on_headers
 
 from stagecraft.apps.users.models import User
-from stagecraft.libs.authorization.http import permission_required
+from stagecraft.libs.authorization.http import (
+    permission_required, _get_resource_role_permissions)
 from stagecraft.libs.views.resource import ResourceView
 
 logger = logging.getLogger(__name__)
@@ -40,11 +41,7 @@ class UserView(ResourceView):
         'email': 'email__iexact',
     }
 
-    permissions = {
-        'get': ['user'],
-        'post': ['user'],
-        'put': ['user'],
-    }
+    permissions = _get_resource_role_permissions('User')
 
     @never_cache
     @vary_on_headers('Authorization')

--- a/stagecraft/libs/authorization/http.py
+++ b/stagecraft/libs/authorization/http.py
@@ -70,6 +70,18 @@ def _get_user_from_database(access_token):
 def _set_user_to_database(access_token, user):
     OAuthUser.objects.cache_user(access_token, user)
 
+def _get_resource_role_permissions(resource, permissions=None):
+    if permissions is None:
+        permissions = settings.ROLES
+    resource_permissions = {"get": set(), "put": set(), "post": set()}
+    for permission in permissions:
+        for k, v in permission["permissions"].items():
+            if k == resource:
+                for method in v:
+                    resource_permissions[method].add(permission["role"])
+
+    return resource_permissions
+
 
 def check_permission(access_token, permission_requested, anon_allowed=True):
     user = _get_user(access_token, anon_allowed)

--- a/stagecraft/libs/authorization/http.py
+++ b/stagecraft/libs/authorization/http.py
@@ -13,6 +13,15 @@ audit_logger = logging.getLogger('stagecraft.audit')
 
 @statsd.timer('get_user.both')
 def _get_user(access_token, anon_allowed):
+    """
+    Attempts to find a user (using the access token ) in
+    either Stagecraft's OAuthUser table or, and as fallback, via a request to
+    GovUK's Signon API.
+
+    Args:
+        access_token: access token from request
+        anon_allowed: whether to allow anonymous users
+    """
     user = None
     if access_token is not None:
 

--- a/stagecraft/libs/authorization/http.py
+++ b/stagecraft/libs/authorization/http.py
@@ -70,6 +70,7 @@ def _get_user_from_database(access_token):
 def _set_user_to_database(access_token, user):
     OAuthUser.objects.cache_user(access_token, user)
 
+
 def _get_resource_role_permissions(resource, permissions=None):
     if permissions is None:
         permissions = settings.ROLES
@@ -87,15 +88,11 @@ def check_permission(access_token, permission_requested, anon_allowed=True):
     user = _get_user(access_token, anon_allowed)
     if user is None:
         return (user, False)
-    if permission_requested is None:
-        permission_requested_set = set()
-    else:
-        permission_requested_set = set(permission_requested)
+    # always allow access if no role requested
+    if not permission_requested:
+        return (user, True)
     user_permissions = set(user['permissions'])
-    has_permission = user is not None and \
-        (permission_requested is None or
-         len(permission_requested_set.intersection(user_permissions)) > 0)
-    return (user, has_permission)
+    return (user, len(permission_requested.intersection(user_permissions)) > 0)
 
 
 def unauthorized(request, message):

--- a/stagecraft/libs/authorization/http.py
+++ b/stagecraft/libs/authorization/http.py
@@ -73,9 +73,16 @@ def _set_user_to_database(access_token, user):
 
 def check_permission(access_token, permission_requested, anon_allowed=True):
     user = _get_user(access_token, anon_allowed)
+    if user is None:
+        return (user, False)
+    if permission_requested is None:
+        permission_requested_set = set()
+    else:
+        permission_requested_set = set(permission_requested)
+    user_permissions = set(user['permissions'])
     has_permission = user is not None and \
         (permission_requested is None or
-         permission_requested in user['permissions'])
+         len(permission_requested_set.intersection(user_permissions)) > 0)
     return (user, has_permission)
 
 

--- a/stagecraft/libs/authorization/http.py
+++ b/stagecraft/libs/authorization/http.py
@@ -41,8 +41,7 @@ def _get_user(access_token, anon_allowed):
             "email": "performance@digital.cabinet-office.gov.uk",
             "name": "Anonymous",
             "organisation_slug": "cabinet-office",
-            "permissions": [
-            ],
+            "permissions": ["anon"],
             "uid": "00000000-0000-0000-0000-000000000000"
         }
 
@@ -90,7 +89,7 @@ def check_permission(access_token, permission_requested, anon_allowed=True):
         return (user, False)
     # always allow access if no role requested
     if not permission_requested:
-        return (user, True)
+        return (user, False)
     user_permissions = set(user['permissions'])
     return (user, len(permission_requested.intersection(user_permissions)) > 0)
 

--- a/stagecraft/libs/authorization/tests/test_http.py
+++ b/stagecraft/libs/authorization/tests/test_http.py
@@ -130,6 +130,21 @@ class CheckPermissionTestCase(TestCase):
 
         assert_that(has_permission, equal_to(False))
 
+    def test_user_with_returns_object_and_true_when_permissions_is_list(self):
+        settings.USE_DEVELOPMENT_USERS = False
+
+        OAuthUser.objects.create(access_token='correct-token',
+                                 uid='my-uid',
+                                 email='jon@example.com',
+                                 permissions=['signin'],
+                                 expires_at=datetime.now() + timedelta(days=1))
+
+        (user, has_permission) = check_permission(
+            'correct-token', ['signin', 'bob'])
+
+        assert_that(user['email'], equal_to('jon@example.com'))
+        assert_that(has_permission, equal_to(True))
+
     def test_user_from_database_should_not_be_returned_if_expired(self):
         settings.USE_DEVELOPMENT_USERS = False
         OAuthUser.objects.create(access_token='correct-token-2',

--- a/stagecraft/libs/views/tests/test_resource.py
+++ b/stagecraft/libs/views/tests/test_resource.py
@@ -73,6 +73,9 @@ class TestResourceView(ResourceView):
 
     was_saved = False
 
+    permissions = {
+        'get': set(['anon']), 'post': set(['anon']), 'put': set(['anon'])}
+
     def update_relationships(self, model, model_json, request, parent):
         self.was_saved = model.pk is not None
 
@@ -159,6 +162,8 @@ class ResourceViewTestCase(TestCase):
         request.method = 'GET'
         for (k, v) in query.items():
             request.GET[k] = v
+
+        view.permissions = {'get': set(['anon'])}
 
         response = view.get(request, **args)
 

--- a/stagecraft/settings/common.py
+++ b/stagecraft/settings/common.py
@@ -121,3 +121,41 @@ DOGSLOW_LOG_TO_FILE = False
 DOGSLOW_TIMER = 1
 DOGSLOW_LOGGER = 'stagecraft.apps'
 DOGSLOW_LOG_LEVEL = 'INFO'
+
+ROLES = [
+    {
+        "role": "dashboard",
+        "permissions": {
+            "Dashboard": ["post", "put"],
+            "Module": ["post", "put"],
+            "ModuleType": ["post", "put"],
+        },
+    },
+    {
+        "role": "signin",
+        "permissions": {
+            "DataGroup": ["get", "post", "put"],
+            "DataSet": ["get", "post", "put"],
+        },
+    },
+    {
+        "role": "organisation",
+        "permissions": {
+            "Node": ["post", "put"],
+            "NodeType": ["post", "put"],
+        },
+    },
+    {
+        "role": "transforms",
+        "permissions": {
+            "Transform": ["post", "put"],
+            "TransformType": ["post", "put"],
+        },
+    },
+    {
+        "role": "user",
+        "permissions": {
+            "User": ["get", "post", "put"],
+        },
+    },
+]

--- a/stagecraft/settings/common.py
+++ b/stagecraft/settings/common.py
@@ -126,9 +126,9 @@ ROLES = [
     {
         "role": "dashboard",
         "permissions": {
-            "Dashboard": ["post", "put"],
-            "Module": ["post", "put"],
-            "ModuleType": ["post", "put"],
+            "Dashboard": ["get", "post", "put"],
+            "Module": ["get", "post", "put"],
+            "ModuleType": ["get", "post", "put"],
         },
     },
     {
@@ -141,21 +141,33 @@ ROLES = [
     {
         "role": "organisation",
         "permissions": {
-            "Node": ["post", "put"],
-            "NodeType": ["post", "put"],
+            "Node": ["get", "post", "put"],
+            "NodeType": ["get", "post", "put"],
         },
     },
     {
         "role": "transforms",
         "permissions": {
-            "Transform": ["post", "put"],
-            "TransformType": ["post", "put"],
+            "Transform": ["get", "post", "put"],
+            "TransformType": ["get", "post", "put"],
         },
     },
     {
         "role": "user",
         "permissions": {
             "User": ["get", "post", "put"],
+        },
+    },
+    {
+        "role": "anon",
+        "permissions": {
+            "Dashboard": ["get"],
+            "Module": ["get"],
+            "ModuleType": ["get"],
+            "Node": ["get"],
+            "NodeType": ["get"],
+            "Transform": ["get"],
+            "TransformType": ["get"],
         },
     },
 ]

--- a/stagecraft/settings/development.py
+++ b/stagecraft/settings/development.py
@@ -37,6 +37,7 @@ DEVELOPMENT_USERS = {
         "name": "Some User",
         "organisation_slug": "cabinet-office",
         "permissions": [
+            "anon",
             "signin",
             "user",
             "admin",


### PR DESCRIPTION
- Define the roles in the common settings file - the roles array is
 loosely based on IAM roles used by AWS
 - Update and refactor the check_permission method to use sets for the
 permission_requested parameter rather than lists
 - Update all tests to use sets rather than lists
 - Update all views to call the new _get_resource_role_permissions
 method rather than explicitly defining the list in each view.