### PR TITLE
Make the creator of a resource the owner and enforce owner-only access

### DIFF
--- a/stagecraft/apps/dashboards/models/dashboard.py
+++ b/stagecraft/apps/dashboards/models/dashboard.py
@@ -5,6 +5,7 @@ from django.db import models
 
 from stagecraft.apps.users.models import User
 from stagecraft.apps.organisation.views import NodeView
+from django.db.models.query import QuerySet
 
 
 def list_to_tuple_pairs(elements):
@@ -26,6 +27,12 @@ class DashboardManager(models.Manager):
                                WHERE name='transactional_services_summaries')
               AND dashboards_dashboard.status='published'
         ''', [filter_string])
+
+    def get_query_set(self):
+        return QuerySet(self.model, using=self._db)
+
+    def for_user(self, user):
+        return self.get_query_set().filter(owners=user)
 
 
 class Dashboard(models.Model):

--- a/stagecraft/apps/dashboards/models/module.py
+++ b/stagecraft/apps/dashboards/models/module.py
@@ -22,6 +22,9 @@ class ModuleManager(models.Manager):
             'data_set__data_group', 'data_set__data_type',
             'type')
 
+    def for_user(self, user):
+        return self.get_queryset().filter(dashboard__owners=user)
+
 
 class ModuleType(models.Model):
     id = models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True)
@@ -89,6 +92,11 @@ class Module(models.Model):
     order = models.IntegerField()
 
     objects = ModuleManager()
+
+    def _get_owners(self):
+        return self.dashboard.owners
+
+    owners = property(_get_owners)
 
     # should run on normal validate
     def validate_options(self):

--- a/stagecraft/apps/dashboards/tests/views/test_dashboard.py
+++ b/stagecraft/apps/dashboards/tests/views/test_dashboard.py
@@ -20,7 +20,7 @@ from stagecraft.apps.dashboards.models.module import Module
 from stagecraft.apps.dashboards.views.dashboard import fetch_dashboard
 from stagecraft.apps.users.models import User
 from stagecraft.libs.authorization.tests.test_http import (
-    with_govuk_signon, govuk_signon_mock)
+    with_govuk_signon)
 from stagecraft.libs.views.utils import to_json
 from stagecraft.libs.views.utils import JsonEncoder
 
@@ -387,6 +387,31 @@ class DashboardViewsGetTestCase(TestCase):
         pass
 
     @with_govuk_signon(permissions=['dashboard'])
+    def test_404_when_user_not_in_ownership_array(self):
+        dashboard = DashboardFactory()
+        user, _ = User.objects.get_or_create(
+            email='not_correct_user.lastname@gov.uk')
+        dashboard.owners.add(user)
+
+        resp = self.client.get('/dashboard/{}'.format(dashboard.slug),
+                               HTTP_AUTHORIZATION='Bearer correct-token')
+
+        assert_that(resp.status_code, equal_to(404))
+
+    @with_govuk_signon(permissions=['dashboard'])
+    def test_404_when_user_not_in_ownership_array_for_any_dashboards(self):
+        dashboard = DashboardFactory()
+        user, _ = User.objects.get_or_create(
+            email='not_correct_user.lastname@gov.uk')
+        dashboard.owners.add(user)
+
+        resp = self.client.get('/dashboards',
+                               HTTP_AUTHORIZATION='Bearer correct-token')
+
+        assert_that(resp.status_code, equal_to(200))
+        assert_that(json.loads(resp.content), equal_to([]))
+
+    @with_govuk_signon(permissions=['dashboard'])
     def test_get_a_dashboard_with_incorrect_id_returns_404(self):
         resp = self.client.get(
             '/dashboard/non-existant-m8',
@@ -440,18 +465,6 @@ class DashboardViewsUpdateTestCase(TestCase):
     @classmethod
     def tearDownClass(cls):
         pass
-
-    @with_govuk_signon(permissions=['dashboard'])
-    def test_404_when_user_not_in_ownership_array(self):
-        dashboard = DashboardFactory()
-        user, _ = User.objects.get_or_create(
-            email='not_correct_user.lastname@gov.uk')
-        dashboard.owners.add(user)
-
-        resp = self.client.get('/dashboard/{}'.format(dashboard.slug),
-                               HTTP_AUTHORIZATION='Bearer correct-token')
-
-        assert_that(resp.status_code, equal_to(404))
 
     @with_govuk_signon(permissions=['dashboard'])
     def test_change_title_of_dashboard_changes_title_of_dashboard(self):
@@ -686,7 +699,7 @@ class DashboardViewsUpdateTestCase(TestCase):
         dashboard_data['links'][0]['url'] = 'https://gov.uk/new-link'
         dashboard_data['links'][0]['title'] = 'new link title'
 
-        resp = self.client.put(
+        self.client.put(
             '/dashboard/{}'.format(dashboard.id),
             json.dumps(dashboard_data, cls=JsonEncoder),
             content_type="application/json",
@@ -744,6 +757,25 @@ class DashboardViewsCreateTestCase(TestCase):
 
         assert_that(resp.status_code, equal_to(200))
         assert_that(Dashboard.objects.count(), equal_to(1))
+
+    @with_govuk_signon(permissions=['dashboard'])
+    def test_create_dashboard_adds_owner(self):
+        department = DepartmentFactory()
+        data = self._get_dashboard_payload(
+            organisation=str(department.id))
+
+        resp = self.client.post(
+            '/dashboard', json.dumps(data),
+            content_type="application/json",
+            HTTP_AUTHORIZATION='Bearer correct-token')
+
+        assert_that(resp.status_code, equal_to(200))
+        dashboard = Dashboard.objects.get(
+            slug=self._get_dashboard_payload()['slug'])
+        assert_that(len(dashboard.owners.all()), equal_to(1))
+        assert_that(
+            dashboard.owners.first().email,
+            equal_to('foobar.lastname@gov.uk'))
 
     @with_govuk_signon(permissions=['dashboard'])
     def test_create_dashboard_fails_with_invalid_organisation_uuid(self):

--- a/stagecraft/apps/dashboards/views/module.py
+++ b/stagecraft/apps/dashboards/views/module.py
@@ -188,6 +188,15 @@ class ModuleView(ResourceView):
     def get(self, request, **kwargs):
         return super(ModuleView, self).get(request, **kwargs)
 
+    @csrf_exempt
+    @method_decorator(never_cache)
+    def put(self, request, **kwargs):
+        return create_http_error(
+            405,
+            "Can't put to a resource,"
+            "update only supported through dashboard",
+            request)
+
     def update_model(self, model, model_json, request, parent):
 
         try:
@@ -195,6 +204,8 @@ class ModuleView(ResourceView):
         except ModuleType.DoesNotExist:
             return create_http_error(404, 'module type not found', request)
 
+        if parent is None:
+            return create_http_error(404, 'no parent dashboard found', request)
         try:
             dashboard = Dashboard.objects.get(id=parent.id)
         except Dashboard.DoesNotExist:

--- a/stagecraft/apps/datasets/models/data_set.py
+++ b/stagecraft/apps/datasets/models/data_set.py
@@ -44,6 +44,9 @@ class DataSetManager(models.Manager):
     def get_query_set(self):
         return DataSetQuerySet(self.model, using=self._db)
 
+    def for_user(self, user):
+        return self.get_query_set().filter(owners=user)
+
 
 @python_2_unicode_compatible
 class DataSet(models.Model):

--- a/stagecraft/apps/datasets/tests/views/test_data_set.py
+++ b/stagecraft/apps/datasets/tests/views/test_data_set.py
@@ -543,6 +543,11 @@ class DataSetsViewsTestCase(TestCase):
             HTTP_AUTHORIZATION='Bearer development-oauth-access-token')
         assert_equal(json.loads(resp.content.decode('utf-8')), expected)
 
+        assert_that(
+            DataSet.objects.get(name=expected['name']).owners.first().email,
+            equal_to('some.user@digital.cabinet-office.gov.uk')
+        )
+
     def test_post_with_name_is_rejected(self):
         data_set = {
             'name': 'group1_type1',

--- a/stagecraft/apps/transforms/models.py
+++ b/stagecraft/apps/transforms/models.py
@@ -10,6 +10,7 @@ from jsonfield import JSONField
 
 from stagecraft.apps.users.models import User
 from stagecraft.apps.datasets.models import DataGroup, DataType
+from django.db.models.query import QuerySet
 from stagecraft.apps.dashboards.models.module import query_param_schema
 
 logger = logging.getLogger(__name__)
@@ -48,7 +49,18 @@ class TransformType(models.Model):
         return None
 
 
+class TransformManager(models.Manager):
+
+    def get_query_set(self):
+        return QuerySet(self.model, using=self._db)
+
+    def for_user(self, user):
+        return self.get_query_set().filter(owners=user)
+
+
 class Transform(models.Model):
+    objects = TransformManager()
+
     id = models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True)
     type = models.ForeignKey(TransformType)
     owners = models.ManyToManyField(User)

--- a/stagecraft/apps/transforms/tests/factories.py
+++ b/stagecraft/apps/transforms/tests/factories.py
@@ -1,7 +1,7 @@
 import factory
 
 from ..models import TransformType, Transform
-from ...datasets.tests.factories import DataTypeFactory
+from ...datasets.tests.factories import DataTypeFactory, DataGroupFactory
 
 
 class TransformTypeFactory(factory.DjangoModelFactory):
@@ -22,5 +22,19 @@ class TransformFactory(factory.DjangoModelFactory):
     type = factory.SubFactory(TransformTypeFactory)
     input_type = factory.SubFactory(DataTypeFactory)
     output_type = factory.SubFactory(DataTypeFactory)
+    query_parameters = {}
+    options = {}
+
+
+class TransformWithDataGroupFactory(factory.DjangoModelFactory):
+
+    class Meta:
+        model = Transform
+
+    type = factory.SubFactory(TransformTypeFactory)
+    input_type = factory.SubFactory(DataTypeFactory)
+    output_type = factory.SubFactory(DataTypeFactory)
+    input_group = factory.SubFactory(DataGroupFactory)
+    output_group = factory.SubFactory(DataGroupFactory)
     query_parameters = {}
     options = {}

--- a/stagecraft/apps/transforms/tests/test_views.py
+++ b/stagecraft/apps/transforms/tests/test_views.py
@@ -2,13 +2,14 @@ import json
 
 from django.test import TestCase
 from hamcrest import (
-    assert_that, equal_to, has_entry,
-    has_item, has_key
+    assert_that, equal_to, has_key
 )
 
-from .factories import TransformTypeFactory, TransformFactory
+from .factories import (TransformTypeFactory, TransformFactory,
+                        TransformWithDataGroupFactory)
 from ...datasets.tests.factories import DataGroupFactory, DataTypeFactory
 from stagecraft.apps.users.models import User
+from stagecraft.apps.transforms.models import Transform
 from stagecraft.libs.authorization.tests.test_http import with_govuk_signon
 
 
@@ -101,6 +102,11 @@ class TransformViewTestCase(TestCase):
             resp_json['output']['data-group'],
             equal_to(output_data_group.name))
 
+        assert_that(
+            Transform.objects.get(id=resp_json['id']).owners.first().email,
+            equal_to('some.user@digital.cabinet-office.gov.uk')
+        )
+
     def test_post_type_not_found(self):
         resp = self.client.post(
             '/transform',
@@ -155,7 +161,7 @@ class TransformViewTestCase(TestCase):
 
         assert_that(resp.status_code, equal_to(400))
 
-    def test_get_allows_any_user(self):
+    def test_get_gets_transform(self):
         transform = TransformFactory()
         resp = self.client.get(
             '/transform/{}'.format(transform.id),
@@ -173,6 +179,57 @@ class TransformViewTestCase(TestCase):
         )
 
     @with_govuk_signon(permissions=['transforms'])
+    def test_get_returns_404_when_user_not_in_ownership_array(self):
+        transform = TransformFactory()
+        assert_that(len(transform.owners.all()), equal_to(0))
+        resp = self.client.get(
+            '/transform/{}'.format(transform.id),
+            HTTP_AUTHORIZATION='Bearer correct-token',
+            content_type='application/json')
+
+        assert_that(resp.status_code, equal_to(404))
+
+    @with_govuk_signon(permissions=['transforms'])
+    def test_list_returns_empty_list_when_user_not_in_ownership_array(self):
+        transform = TransformFactory()
+        assert_that(len(transform.owners.all()), equal_to(0))
+        resp = self.client.get(
+            '/transform/',
+            HTTP_AUTHORIZATION='Bearer correct-token',
+            content_type='application/json')
+
+        assert_that(json.loads(resp.content), equal_to([]))
+
+    @with_govuk_signon(permissions=['transforms'])
+    def test_list_returns_transform_in_list_when_user_in_ownership_array(self):
+        transform = TransformWithDataGroupFactory()
+        user, _ = User.objects.get_or_create(
+            email='foobar.lastname@gov.uk')
+        transform.owners.add(user)
+        resp = self.client.get(
+            '/transform/',
+            HTTP_AUTHORIZATION='Bearer correct-token',
+            content_type='application/json')
+
+        resp_json = json.loads(resp.content)
+        assert_that(len(resp_json), equal_to(1))
+        assert_that(
+            resp_json[0]['type']['id'],
+            equal_to(str(transform.type.id)))
+        assert_that(
+            resp_json[0]['input']['data-type'],
+            equal_to(transform.input_type.name))
+        assert_that(
+            resp_json[0]['input']['data-group'],
+            equal_to(transform.input_group.name))
+        assert_that(
+            resp_json[0]['output']['data-type'],
+            equal_to(transform.output_type.name))
+        assert_that(
+            resp_json[0]['output']['data-group'],
+            equal_to(transform.output_group.name))
+
+    @with_govuk_signon(permissions=['transforms'])
     def test_404_on_put_when_user_not_in_ownership_array(self):
         transform = TransformFactory()
         user, _ = User.objects.get_or_create(
@@ -187,3 +244,29 @@ class TransformViewTestCase(TestCase):
         )
 
         assert_that(resp.status_code, equal_to(404))
+
+    @with_govuk_signon(permissions=['transforms'])
+    def test_successful_put_when_user_in_ownership_array(self):
+        transform = TransformFactory()
+        user, _ = User.objects.get_or_create(
+            email='foobar.lastname@gov.uk')
+        transform.owners.add(user)
+
+        resp = self.client.put(
+            '/transform/{}'.format(transform.id),
+            data=json.dumps({
+                "type_id": str(TransformTypeFactory().id),
+                "input": {
+                    "data-type": DataTypeFactory().name,
+                },
+                "query-parameters": {},
+                "options": {},
+                "output": {
+                    "data-type": DataTypeFactory().name
+                }
+            }),
+            HTTP_AUTHORIZATION='Bearer correct-token',
+            content_type='application/json'
+        )
+
+        assert_that(resp.status_code, equal_to(200))


### PR DESCRIPTION
When a resource is created, the user creating it is added to the list of
owners. In the case of dashboards, datasets and transforms the list is
associated to the model directly.

In the case of modules, ownership is delegated to the dashboard the
module is associated with.

The owner is the only non-privileged user who can view and modify their
resources.

This adds various tests and improves testing in places where it was
lacking. Specifically, ownership interactions across resources is
tested, and transforms are better tested.