### PR TITLE
Consolidate roles and permissions with Admin App

### DIFF
--- a/stagecraft/apps/datasets/tests/views/test_data_set.py
+++ b/stagecraft/apps/datasets/tests/views/test_data_set.py
@@ -322,10 +322,10 @@ class DataSetsViewsTestCase(TestCase):
             response_object = json.loads(resp.content.decode('utf-8'))
             assert_equal(len(response_object), 6)
 
-    def test_list_returns_all_data_sets_if_user_has_dashboard_editor_permission(self):  # noqa
+    def test_list_returns_all_data_sets_if_user_has_admin_permission(self):  # noqa
         settings.USE_DEVELOPMENT_USERS = False
         signon = govuk_signon_mock(
-            permissions=['signin', 'dataset', 'dashboard-editor'])
+            permissions=['signin', 'admin'])
         with HTTMock(signon):
             resp = self.client.get(
                 '/data-sets',

--- a/stagecraft/libs/views/resource.py
+++ b/stagecraft/libs/views/resource.py
@@ -74,7 +74,7 @@ class ResourceView(View):
     def list(self, request, **kwargs):
         user = kwargs.get('user', None)
         additional_filters = kwargs.get('additional_filters', {})
-        unfiltered_roles = {'admin', 'dashboard-editor'}
+        unfiltered_roles = {'admin'}
 
         should_filter = user and (len(set(user['permissions']).intersection(
             unfiltered_roles)) == 0)

--- a/stagecraft/settings/common.py
+++ b/stagecraft/settings/common.py
@@ -132,6 +132,35 @@ ROLES = [
         },
     },
     {
+        "role": "dashboard-editor",
+        "permissions": {
+            "Dashboard": ["get", "post", "put"],
+            "Module": ["get", "post", "put"],
+            "ModuleType": ["get"],
+            "DataGroup": ["get", "post"],
+            "DataSet": ["get", "post"],
+            "Node": ["get"],
+            "NodeType": ["get"],
+            "Transform": ["get", "post"],
+            "TransformType": ["get"],
+        },
+    },
+    {
+        "role": "admin",
+        "permissions": {
+            "Dashboard": ["get", "post", "put"],
+            "Module": ["get", "post", "put"],
+            "ModuleType": ["get", "post", "put"],
+            "DataGroup": ["get", "post", "put"],
+            "DataSet": ["get", "post", "put"],
+            "Node": ["get", "post", "put"],
+            "NodeType": ["get", "post", "put"],
+            "Transform": ["get", "post", "put"],
+            "TransformType": ["get", "post", "put"],
+            "User": ["get", "post", "put"],
+        },
+    },
+    {
         "role": "signin",
         "permissions": {
             "DataGroup": ["get", "post", "put"],


### PR DESCRIPTION
 - Users with the dashboard editor role should only see their own
 dashboards, not all
 - Introduced admin and dashboard-editor roles and permissions

See story: https://www.pivotaltracker.com/story/show/97212736