### PR TITLE
Replace truncated slugs

### DIFF
--- a/stagecraft/apps/dashboards/migrations/0004_auto_20150623_1454.py
+++ b/stagecraft/apps/dashboards/migrations/0004_auto_20150623_1454.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.core.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dashboards', '0003_dashboard_owners'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='dashboard',
+            name='slug',
+            field=models.CharField(unique=True, max_length=1000, validators=[django.core.validators.RegexValidator('^[-a-z0-9]+$', message='Slug can only contain lower case letters, numbers or hyphens')]),
+        ),
+    ]

--- a/stagecraft/apps/dashboards/models/dashboard.py
+++ b/stagecraft/apps/dashboards/models/dashboard.py
@@ -37,7 +37,7 @@ class Dashboard(models.Model):
         message='Slug can only contain lower case letters, numbers or hyphens'
     )
     slug = models.CharField(
-        max_length=90,
+        max_length=1000,
         unique=True,
         validators=[
             slug_validator

--- a/stagecraft/tools/import_dashboards.py
+++ b/stagecraft/tools/import_dashboards.py
@@ -109,6 +109,8 @@ def import_dashboard(record, summaries, dry_run=True, publish=False,
         dashboard = set_dashboard_attributes(dashboard, record, publish)
 
     if dashboard.pk is None or dashboard.module_set.count() == 0:
+        if not dry_run:
+            dashboard.save()
         print('Updating modules on {}'.format(dashboard.slug))
         dataset = get_dataset()
         import_modules(dashboard, dataset, record, summaries)

--- a/stagecraft/tools/import_dashboards.py
+++ b/stagecraft/tools/import_dashboards.py
@@ -106,14 +106,14 @@ def dashboard_from_record(record):
             Dashboard.objects.filter(slug=record['tx_truncated']).count():
         dashboard = Dashboard.objects.get(slug=record['tx_truncated'])
         dashboard.slug = record['tx_id']
-        print "Updating truncated slug to {}".format(record['tx_id'])
+        print("Updating truncated slug to {}".format(record['tx_id']))
 
     elif 'tx_truncated' in record and list(Dashboard.objects.by_tx_id(
             record['tx_truncated'])):
         dashboard = list(
             Dashboard.objects.by_tx_id(record['tx_truncated'])).pop()
         dashboard.slug = record['tx_id']
-        print "Updating truncated slug to {}".format(record['tx_id'])
+        print("Updating truncated slug to {}".format(record['tx_id']))
 
     elif Dashboard.objects.filter(slug=record['tx_id']).count():
         dashboard = Dashboard.objects.get(slug=record['tx_id'])

--- a/stagecraft/tools/import_dashboards.py
+++ b/stagecraft/tools/import_dashboards.py
@@ -101,19 +101,20 @@ def import_dashboard(record, summaries, dry_run=True, publish=False,
 
 
 def dashboard_from_record(record):
+    def set_truncated_slug_to_full_slug(full_slug):
+        dashboard.slug = full_slug
+        print("Setting truncated slug to {}".format(full_slug))
 
     if 'tx_truncated' in record and \
             Dashboard.objects.filter(slug=record['tx_truncated']).count():
         dashboard = Dashboard.objects.get(slug=record['tx_truncated'])
-        dashboard.slug = record['tx_id']
-        print("Updating truncated slug to {}".format(record['tx_id']))
+        set_truncated_slug_to_full_slug(record['tx_id'])
 
     elif 'tx_truncated' in record and list(Dashboard.objects.by_tx_id(
             record['tx_truncated'])):
         dashboard = list(
             Dashboard.objects.by_tx_id(record['tx_truncated'])).pop()
-        dashboard.slug = record['tx_id']
-        print("Updating truncated slug to {}".format(record['tx_id']))
+        set_truncated_slug_to_full_slug(record['tx_id'])
 
     elif Dashboard.objects.filter(slug=record['tx_id']).count():
         dashboard = Dashboard.objects.get(slug=record['tx_id'])

--- a/stagecraft/tools/import_organisations.py
+++ b/stagecraft/tools/import_organisations.py
@@ -279,13 +279,10 @@ def node_types():
 
 def create_edge(parent_id, child_id):
     cursor = connection.cursor()
-    try:
-        cursor.execute(
-            'INSERT INTO organisation_node_parents(from_node_id, to_node_id) VALUES(%s,%s);',  # noqa
-            [child_id, parent_id]
-        )
-    except django.db.utils.IntegrityError as ie:
-        print(str(ie))
+    cursor.execute(
+        'INSERT INTO organisation_node_parents(from_node_id, to_node_id) VALUES(%s,%s);',  # noqa
+        [child_id, parent_id]
+    )
 
 
 def create_nodes(nodes, edges, type_to_NodeType):
@@ -303,11 +300,7 @@ def create_nodes(nodes, edges, type_to_NodeType):
             abbreviation=node[3],
             typeOf=type_to_NodeType[node[4]],
         )
-        try:
-            db_node.save()
-        except django.db.utils.DataError:
-            print(db_node.__dict__)
-            continue
+        db_node.save()
 
         nodes_to_db[node[0]] = db_node
 

--- a/stagecraft/tools/import_organisations.py
+++ b/stagecraft/tools/import_organisations.py
@@ -279,10 +279,13 @@ def node_types():
 
 def create_edge(parent_id, child_id):
     cursor = connection.cursor()
-    cursor.execute(
-        'INSERT INTO organisation_node_parents(from_node_id, to_node_id) VALUES(%s,%s);',  # noqa
-        [child_id, parent_id]
-    )
+    try:
+        cursor.execute(
+            'INSERT INTO organisation_node_parents(from_node_id, to_node_id) VALUES(%s,%s);',  # noqa
+            [child_id, parent_id]
+        )
+    except django.db.utils.IntegrityError as ie:
+        print str(ie)
 
 
 def create_nodes(nodes, edges, type_to_NodeType):
@@ -300,7 +303,12 @@ def create_nodes(nodes, edges, type_to_NodeType):
             abbreviation=node[3],
             typeOf=type_to_NodeType[node[4]],
         )
-        db_node.save()
+        try:
+            db_node.save()
+        except django.db.utils.DataError:
+            print db_node.__dict__
+            continue
+
         nodes_to_db[node[0]] = db_node
 
     for edge in edges:

--- a/stagecraft/tools/import_organisations.py
+++ b/stagecraft/tools/import_organisations.py
@@ -285,7 +285,7 @@ def create_edge(parent_id, child_id):
             [child_id, parent_id]
         )
     except django.db.utils.IntegrityError as ie:
-        print str(ie)
+        print(str(ie))
 
 
 def create_nodes(nodes, edges, type_to_NodeType):
@@ -306,7 +306,7 @@ def create_nodes(nodes, edges, type_to_NodeType):
         try:
             db_node.save()
         except django.db.utils.DataError:
-            print db_node.__dict__
+            print(db_node.__dict__)
             continue
 
         nodes_to_db[node[0]] = db_node

--- a/stagecraft/tools/spreadsheets.py
+++ b/stagecraft/tools/spreadsheets.py
@@ -252,7 +252,7 @@ class SpreadsheetMunger:
             tx_id = self._replace_unicode(record['tx_id'])
             if len(tx_id) > 90:
                 print('Truncated slug: {} to {}'.format(tx_id, tx_id[:90]))
-                tx_id = tx_id[:90]
+                record['tx_truncated'] = tx_id[:90]
             record['tx_id'] = tx_id
 
     def load(self, client_email, private_key):


### PR DESCRIPTION
Check whether a dashboard slug has been truncated during import. Update it to the full length slug if so.

Adds a migration to increase slug field length.