### PR TITLE
If dashboard slug truncated set to original value

### DIFF
--- a/stagecraft/apps/dashboards/migrations/0004_auto_20150623_1454.py
+++ b/stagecraft/apps/dashboards/migrations/0004_auto_20150623_1454.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.core.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dashboards', '0003_dashboard_owners'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='dashboard',
+            name='slug',
+            field=models.CharField(unique=True, max_length=1000, validators=[django.core.validators.RegexValidator('^[-a-z0-9]+$', message='Slug can only contain lower case letters, numbers or hyphens')]),
+        ),
+    ]

--- a/stagecraft/apps/dashboards/models/dashboard.py
+++ b/stagecraft/apps/dashboards/models/dashboard.py
@@ -44,7 +44,7 @@ class Dashboard(models.Model):
         message='Slug can only contain lower case letters, numbers or hyphens'
     )
     slug = models.CharField(
-        max_length=90,
+        max_length=1000,
         unique=True,
         validators=[
             slug_validator

--- a/stagecraft/tools/import_dashboards.py
+++ b/stagecraft/tools/import_dashboards.py
@@ -81,27 +81,52 @@ def set_dashboard_attributes(dashboard, record, publish):
 
 def import_dashboard(record, summaries, dry_run=True, publish=False,
                      update=False):
-    try:
-        dashboard = Dashboard.objects.get(slug=record['tx_id'])
-    except Dashboard.DoesNotExist:
-        dashboards = list(Dashboard.objects.by_tx_id(record['tx_id']))
-        if len(dashboards) > 0:
-            dashboard = dashboards[0]
-        else:
-            dashboard = Dashboard()
+
+    dashboard = dashboard_from_record(record)
 
     if update or not record['high_volume']:
         dashboard = set_dashboard_attributes(dashboard, record, publish)
 
     if dashboard.pk is None or dashboard.module_set.count() == 0:
+        if not dry_run:
+            dashboard.save()
         print('Updating modules on {}'.format(dashboard.slug))
         dataset = get_dataset()
-        import_modules(dashboard, dataset, record, summaries)
+        import_modules(dashboard, dataset, record, summaries, dry_run)
 
     if dry_run:
         dashboard.full_clean()
     else:
         dashboard.save()
+
+
+def dashboard_from_record(record):
+    def set_truncated_slug_to_full_slug(full_slug):
+        dashboard.slug = full_slug
+        print("Setting truncated slug to {}".format(full_slug))
+
+    if 'tx_truncated' in record and \
+            Dashboard.objects.filter(slug=record['tx_truncated']).count():
+        dashboard = Dashboard.objects.get(slug=record['tx_truncated'])
+        set_truncated_slug_to_full_slug(record['tx_id'])
+
+    elif 'tx_truncated' in record and list(Dashboard.objects.by_tx_id(
+            record['tx_truncated'])):
+        dashboard = list(
+            Dashboard.objects.by_tx_id(record['tx_truncated'])).pop()
+        set_truncated_slug_to_full_slug(record['tx_id'])
+
+    elif Dashboard.objects.filter(slug=record['tx_id']).count():
+        dashboard = Dashboard.objects.get(slug=record['tx_id'])
+
+    elif list(Dashboard.objects.by_tx_id(record['tx_id'])):
+        dashboard = list(Dashboard.objects.by_tx_id(record['tx_id'])).pop()
+
+    else:
+        dashboard = Dashboard()
+        dashboard.slug = record['tx_id']
+
+    return dashboard
 
 
 def determine_modules_for_dashboard(summaries, tx_id):
@@ -145,7 +170,7 @@ def determine_modules_for_dashboard(summaries, tx_id):
     return module_types
 
 
-def import_modules(dashboard, dataset, record, summaries):
+def import_modules(dashboard, dataset, record, summaries, dry_run):
 
     module_types = determine_modules_for_dashboard(summaries, record['tx_id'])
     modules = []

--- a/stagecraft/tools/spreadsheets.py
+++ b/stagecraft/tools/spreadsheets.py
@@ -252,7 +252,7 @@ class SpreadsheetMunger:
             tx_id = self._replace_unicode(record['tx_id'])
             if len(tx_id) > 90:
                 print('Truncated slug: {} to {}'.format(tx_id, tx_id[:90]))
-                tx_id = tx_id[:90]
+                record['tx_truncated'] = tx_id[:90]
             record['tx_id'] = tx_id
 
     def load(self, client_email, private_key):


### PR DESCRIPTION
Add migrations to increase character limit for slug fields
to handle longer slugs for bis dashboards.