### PR TITLE
Update key used to order modules on dashboard.

### DIFF
--- a/stagecraft/tools/import_dashboards.py
+++ b/stagecraft/tools/import_dashboards.py
@@ -183,7 +183,7 @@ def import_modules(dashboard, dataset, record, summaries, dry_run):
         modules.append(import_tc_module(record, dashboard, dataset))
     if module_types.get('cost_per_transaction'):
         modules.append(import_cpt_module(record, dashboard, dataset))
-    if module_types.get('transactions_per_year'):
+    if module_types.get('transactions_per_quarter'):
         modules.append(import_tpq_module(record, dashboard, dataset))
     if module_types.get('digital_takeup'):
         modules.append(import_dtu_module(record, dashboard, dataset))


### PR DESCRIPTION
Modules of type transactions per quarter are only added to the
dashboard if the transactions per year module type key exists. As
both module types are always added to the dashboard this doesn't
seem to have caused any problems yet, but it has been fixed for
clarity.