### PR TITLE
Updating module query_params to untruncated slug

### DIFF
--- a/stagecraft/tools/import_dashboards.py
+++ b/stagecraft/tools/import_dashboards.py
@@ -87,7 +87,8 @@ def import_dashboard(record, summaries, dry_run=True, publish=False,
     if update or not record['high_volume']:
         dashboard = set_dashboard_attributes(dashboard, record, publish)
 
-    if dashboard.pk is None or dashboard.module_set.count() == 0:
+    if(dashboard.pk is None or dashboard.module_set.count() == 0
+       or 'tx_truncated' in record):
         if not dry_run:
             dashboard.save()
         print('Updating modules on {}'.format(dashboard.slug))


### PR DESCRIPTION
We believe it would be safe to do this for non truncated but it's
probably better to limit it and then perhaps take out the truncated slug
related code after all the data is migrated. As a result the test is
pretty long - it should be okay if we will tidy this up anyway.