### PR TITLE
Create digital takeup module even when value 0

### DIFF
--- a/stagecraft/tools/import_dashboards.py
+++ b/stagecraft/tools/import_dashboards.py
@@ -158,11 +158,11 @@ def determine_modules_for_dashboard(summaries, tx_id):
 
     digital_takeup = False
     for datum in seasonal_data:
-        if datum.get('digital_takeup'):
+        if datum.get('digital_takeup') is not None:
             digital_takeup = True
             break
     for datum in quarterly_data:
-        if datum.get('digital_takeup'):
+        if datum.get('digital_takeup') is not None:
             digital_takeup = True
             break
     if digital_takeup:

--- a/stagecraft/tools/tests/test_import_dashboards.py
+++ b/stagecraft/tools/tests/test_import_dashboards.py
@@ -342,3 +342,71 @@ def test_cost_per_transaction_present():
         'transactions_per_quarter': True,
         'cost_per_transaction': True,
     }))
+
+
+def test_digital_takeup_present_seasonal_when_0():
+    summaries = [
+        {
+            'service_id': 'tx_id',
+            'type': 'seasonally-adjusted',
+            'digital_takeup': 0,
+        }
+    ]
+    module_types = determine_modules_for_dashboard(summaries, 'tx_id')
+
+    assert_that(module_types, has_entries({
+        'transactions_per_year': True,
+        'transactions_per_quarter': True,
+        'digital_takeup': True,
+    }))
+
+
+def test_digital_takeup_present_quarterly_when_0():
+    summaries = [
+        {
+            'service_id': 'tx_id',
+            'type': 'quarterly',
+            'digital_takeup': 0,
+        }
+    ]
+    module_types = determine_modules_for_dashboard(summaries, 'tx_id')
+
+    assert_that(module_types, has_entries({
+        'transactions_per_year': True,
+        'transactions_per_quarter': True,
+        'digital_takeup': True,
+    }))
+
+
+def test_total_cost_present_when_0():
+    summaries = [
+        {
+            'service_id': 'tx_id',
+            'type': 'seasonally-adjusted',
+            'total_cost': 0,
+        }
+    ]
+    module_types = determine_modules_for_dashboard(summaries, 'tx_id')
+
+    assert_that(module_types, has_entries({
+        'transactions_per_year': True,
+        'transactions_per_quarter': True,
+        'total_cost': True,
+    }))
+
+
+def test_cost_per_transaction_present_when_0():
+    summaries = [
+        {
+            'service_id': 'tx_id',
+            'type': 'seasonally-adjusted',
+            'cost_per_transaction': 0,
+        }
+    ]
+    module_types = determine_modules_for_dashboard(summaries, 'tx_id')
+
+    assert_that(module_types, has_entries({
+        'transactions_per_year': True,
+        'transactions_per_quarter': True,
+        'cost_per_transaction': True,
+    }))


### PR DESCRIPTION
The summaries page will no show these 0s so not having a module on the
dashboard is confusing. This seems to have originally been prevent
deliberately though as the other modules have a not None check. Is
digital takeup a special case? If so the real change should be changing
the transform to ignore only 0s from digital takeup. It's worth noting
that the totals on the services page also ignore 0s (also for digital
takeup?) again. Was this deliberate?