### PR TITLE
Add filter_by_prefix to query_parameters schema

### DIFF
--- a/stagecraft/apps/dashboards/models/module.py
+++ b/stagecraft/apps/dashboards/models/module.py
@@ -255,6 +255,12 @@ query_param_schema = {
             "items": {
                 "type": "string"
             }
-        }
+        },
+        "filter_by_prefix": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
     }
 }


### PR DESCRIPTION
This query parameter was introduced into Backdrop in January 2015

https://github.com/alphagov/backdrop/commit/6f56fa848a59046eb00b0b4893bf8f23e688b08f

Stagecraft has never been updated to allow modules to make use of the
parameter when querying for data. It is very useful for pulling out a
group of keys to then be run through the rate transform.