### PR TITLE
Disable deleting a sub_resource

### DIFF
--- a/stagecraft/libs/views/resource.py
+++ b/stagecraft/libs/views/resource.py
@@ -302,6 +302,10 @@ class ResourceView(View):
         if id is None:
             return create_http_error(400, 'id not provided', request)
 
+        if kwargs.get('sub_resource'):
+            return create_http_error(
+                405, 'cannot delete a sub_resource', request)
+
         model = self.by_id(request, id_field, id, user=user)
         if model is None:
             return create_http_error(404, 'model not found', request)

--- a/stagecraft/libs/views/tests/test_resource.py
+++ b/stagecraft/libs/views/tests/test_resource.py
@@ -442,6 +442,14 @@ class ResourceViewTestCase(TestCase):
         assert_that(status_code, is_(200))
         assert_that(sub_resource, contains(has_entry("foo", "bar")))
 
+    def test_sub_resource_delete_returns_405(self):
+        node = NodeFactory()
+        status_code, sub_resource = self.delete(args={
+            "id": node.id,
+            "sub_resource": "child"})
+
+        assert_that(status_code, is_(405))
+
     def test_if_post_with_id_bad_request(self):
         status_code, resp = self.post(args={
             'id': 'fc1457d3-d4fe-41a5-8717-b412bee388e4',


### PR DESCRIPTION
At the moment the semantics around deleting a sub resource are not
defined so we should deny this. @jcbashdown 