### PR TITLE
Add ability to create datasets and transforms without users.

### DIFF
--- a/stagecraft/apps/datasets/migrations/0005_auto_20150707_1439.py
+++ b/stagecraft/apps/datasets/migrations/0005_auto_20150707_1439.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('datasets', '0004_copy_user_datasets'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='dataset',
+            name='owners',
+            field=models.ManyToManyField(to='users.User', blank=True),
+        ),
+    ]

--- a/stagecraft/apps/datasets/models/data_set.py
+++ b/stagecraft/apps/datasets/models/data_set.py
@@ -71,7 +71,7 @@ class DataSet(models.Model):
                                    verbose_name='created (UTC)')
     modified = models.DateTimeField(auto_now=True,
                                     verbose_name='modified (UTC)')
-    owners = models.ManyToManyField('users.User')
+    owners = models.ManyToManyField('users.User', blank=True)
     data_group = models.ForeignKey(
         DataGroup,
         on_delete=models.PROTECT,

--- a/stagecraft/apps/transforms/migrations/0003_auto_20150707_1439.py
+++ b/stagecraft/apps/transforms/migrations/0003_auto_20150707_1439.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transforms', '0002_transform_owners'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='transform',
+            name='owners',
+            field=models.ManyToManyField(to='users.User', blank=True),
+        ),
+    ]

--- a/stagecraft/apps/transforms/models.py
+++ b/stagecraft/apps/transforms/models.py
@@ -63,7 +63,7 @@ class Transform(models.Model):
 
     id = models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True)
     type = models.ForeignKey(TransformType)
-    owners = models.ManyToManyField(User)
+    owners = models.ManyToManyField(User, blank=True)
 
     input_group = models.ForeignKey(
         DataGroup, null=True,


### PR DESCRIPTION
Add ability to create datasets and transforms without owners in django admin and forms in general by setting owners field blank property.
Also add tests for this.

https://www.pivotaltracker.com/story/show/97798458