### PR TITLE
Switch to container based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,4 @@ branches:
 notifications:
   email: false
 cache: pip
+sudo: false


### PR DESCRIPTION
Travis support a container based infrastructure for running jobs -

http://docs.travis-ci.com/user/workers/container-based-infrastructure/

This should make builds start faster, and enable us to cache the pip
downloads between jobs, which should speed up builds.