### PR TITLE
Use tx notes on costs for costs

### DIFF
--- a/stagecraft/tools/import_dashboards.py
+++ b/stagecraft/tools/import_dashboards.py
@@ -31,7 +31,6 @@ def import_dashboards(summaries, update=False,
         'names_service_slug': 10,
         'names_tx_id': 19,
         'names_other_notes': 17,
-        'names_notes': 3,
         'names_description': 8
     })
     records = loader.load(client_email, private_key)

--- a/stagecraft/tools/import_organisations.py
+++ b/stagecraft/tools/import_organisations.py
@@ -79,7 +79,6 @@ def load_data(client_email, private_key):
         'names_service_slug': 10,
         'names_tx_id': 19,
         'names_other_notes': 17,
-        'names_notes': 3,
         'names_description': 8
     })
     records = spreadsheets.load(client_email, private_key)

--- a/stagecraft/tools/redirects.py
+++ b/stagecraft/tools/redirects.py
@@ -96,7 +96,6 @@ if __name__ == '__main__':
         'names_service_slug': 10,
         'names_tx_id': 19,
         'names_other_notes': 17,
-        'names_notes': 3,
         'names_description': 8
     })
     results = munger.load(client_email, private_key)

--- a/stagecraft/tools/spreadsheets.py
+++ b/stagecraft/tools/spreadsheets.py
@@ -59,8 +59,6 @@ class SpreadsheetMunger:
         self.names_service_name = positions['names_service_name']
         # "Proposed URL1 (name of service) e.g. /carers-allowance",
         self.names_service_slug = positions['names_service_slug']
-        # "Liz notes",
-        self.names_notes = positions['names_notes']
         # "Other notes",
         self.names_other_notes = positions['names_other_notes']
         # "Slug [do not edit]"
@@ -145,9 +143,6 @@ class SpreadsheetMunger:
 
         if row[self.names_description]:
             record['description'] = row[self.names_description]
-        # description-extra is not present in the names spreadsheet
-        if row[self.names_notes]:
-            record['costs'] = row[self.names_notes]
         if row[self.names_other_notes]:
             record['other_notes'] = row[self.names_other_notes]
 

--- a/stagecraft/tools/tests/test_import_dashboards.py
+++ b/stagecraft/tools/tests/test_import_dashboards.py
@@ -36,7 +36,6 @@ def test_attributes_from_record():
         'names_service_slug': 10,
         'names_tx_id': 19,
         'names_other_notes': 17,
-        'names_notes': 3,
         'names_description': 8,
     })
 
@@ -76,7 +75,6 @@ def test_truncated_slug_is_replaced():
         'names_service_slug': 10,
         'names_tx_id': 19,
         'names_other_notes': 17,
-        'names_notes': 3,
         'names_description': 8,
     })
 
@@ -116,7 +114,6 @@ def test_truncated_slug_is_replaced_in_modules():
         'names_service_slug': 10,
         'names_tx_id': 19,
         'names_other_notes': 17,
-        'names_notes': 3,
         'names_description': 8,
     })
 

--- a/stagecraft/tools/tests/test_spreadsheet.py
+++ b/stagecraft/tools/tests/test_spreadsheet.py
@@ -23,7 +23,6 @@ def test_merge():
         'names_service_slug': 10,
         'names_tx_id': 19,
         'names_other_notes': 17,
-        'names_notes': 3,
         'names_description': 8,
     })
 
@@ -55,7 +54,6 @@ def test_no_agency_abbr():
         'names_service_slug': 10,
         'names_tx_id': 19,
         'names_other_notes': 17,
-        'names_notes': 3,
         'names_description': 8,
     })
 


### PR DESCRIPTION
In the past is was possible this was overridden but response to liz's
notes column in the name spreadsheet. When I made some changes I messed
up further and switched this to liz's notes. It should be neither. tx
spreadsheet is the canonical source of notes on costs.

It looks like it actually was completely correct in import_dashboards (just not elsewhere in the past) until I came in with my big copy and paste. We didn't notice any problem because only import_dashboards uses this field. Not the things I broke earlier.