### PR TITLE
Update location of json log file

### DIFF
--- a/stagecraft/settings/production.py
+++ b/stagecraft/settings/production.py
@@ -57,13 +57,13 @@ LOGGING = {
         'json_log': {
             'level': 'DEBUG',
             'class': 'logging.FileHandler',
-            'filename': BASE_DIR + "/log/stagecraft.log.json",
+            'filename': BASE_DIR + "/log/production.json.log",
             'formatter': 'logstash_json',
         },
         'json_audit_log': {
             'level': 'DEBUG',
             'class': 'logging.handlers.RotatingFileHandler',
-            'filename': BASE_DIR + "/log/audit/stagecraft.log.json",
+            'filename': BASE_DIR + "/log/audit/stagecraft.json.log",
             'maxBytes': 4 * 1024 * 1024,
             'backupCount': 2,
             'formatter': 'logstash_json',


### PR DESCRIPTION
Renaming the json log file to production.json.log means that it will get
rotated correctly on gov.uk infrastructure, as it matches the *.log glob
the log rotation uses. It also means it is easy to add a logstream
config for - this isnt currently enabled, but using the filename
production.json.log will make this a simple switch on the govuk::app
defined type in gov.uk puppet This will break logstreaming in the
current infrastructure unless there is a corresponding change in
pp-puppet