### PR TITLE
Allow owners to be removed from datasets and transforms

### DIFF
--- a/stagecraft/apps/datasets/admin/data_set.py
+++ b/stagecraft/apps/datasets/admin/data_set.py
@@ -48,6 +48,8 @@ class DataSetAdmin(reversion.VersionAdmin):
     search_fields = ['name']
     list_display = ('name', 'data_group', 'data_type', 'data_location',
                     'created', 'modified', 'published')
+    filter_horizontal = ('owners',)
+
     fields = (
         'data_group',
         'data_type',

--- a/stagecraft/apps/transforms/admin.py
+++ b/stagecraft/apps/transforms/admin.py
@@ -10,6 +10,7 @@ class TransformTypeAdmin(admin.ModelAdmin):
 class TransformAdmin(admin.ModelAdmin):
     list_display = (
         'input_group', 'input_type', 'output_group', 'output_type',)
+    filter_horizontal = ('owners',)
 
 
 admin.site.register(TransformType, TransformTypeAdmin)


### PR DESCRIPTION
Add filter-horizontal interface to django admin for datasets and transforms which makes it easier
 to add multiple owners, clearer which owners are selected and also possible to remove owners once
added.