### PR TITLE
Remove guidance on govuk dev vm and trusty

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,16 +179,8 @@ Tests which further specify the behaviour of this can be found in `test_copy_dat
 # Running on gov.uk dev vm
 
 To run on the [gov.uk dev vm](https://github.gds/gds/puppet/tree/master/development),
-you must make sure you provision the trusty vm, as this contains the correct
-version of postgres, 9.3, that stagecraft relies on. To do this, make sure you
 
-`export govuk_dev_dist=trusty`
-
-before running vagrant up. You will need to do this whenever running the vm - if
-you are only working on performance platform, you may want to add this to your
-shell config so it is always set.
-
-You will then need to add a hosts entry in your /etc/hosts file for 
+You will need to add a hosts entry in your /etc/hosts file for 
 
 `192.168.185.152 stagecraft.dev.gov.uk`
 


### PR DESCRIPTION
Since gds/puppet#3159, the gov.uk dev vm defaults to trusty, so we no
longer need to do anything special to make sure we run trusty.