### PR TITLE
Create collector types

### DIFF
--- a/stagecraft/apps/collectors/migrations/0002_collectortype_slug.py
+++ b/stagecraft/apps/collectors/migrations/0002_collectortype_slug.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.core.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('collectors', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='collectortype',
+            name='slug',
+            field=models.CharField(default='', unique=True, max_length=256, validators=[django.core.validators.RegexValidator(b'^[-a-z0-9]+$', message=b'Slug can only contain lower case letters, numbers or hyphens')]),
+            preserve_default=False,
+        ),
+    ]

--- a/stagecraft/apps/collectors/models.py
+++ b/stagecraft/apps/collectors/models.py
@@ -54,6 +54,18 @@ class CollectorType(models.Model):
     id = models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True)
     name = models.CharField(max_length=256, unique=True)
 
+    slug_validator = RegexValidator(
+        '^[-a-z0-9]+$',
+        message='Slug can only contain lower case letters, numbers or hyphens'
+    )
+    slug = models.CharField(
+        max_length=256,
+        unique=True,
+        validators=[
+            slug_validator
+        ]
+    )
+
     provider = models.ForeignKey(Provider)
 
     function_validator = RegexValidator(

--- a/stagecraft/apps/collectors/schemas/ga-contrib-content-table/descriptor.json
+++ b/stagecraft/apps/collectors/schemas/ga-contrib-content-table/descriptor.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "name": {
+            "type": "string",
+            "pattern": "^[a-z-]+$"
+        },
+        "provider": {
+            "type": "string"
+        },
+        "entry_point": {
+            "type": "string",
+            "pattern": "^[a-z_\\.]+$"
+        }
+    },
+    "title": "Google Analytics Content Table",
+    "type": "object",
+    "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/ga-contrib-content-table/options.json
+++ b/stagecraft/apps/collectors/schemas/ga-contrib-content-table/options.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "plugins": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "filtersets": {
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        }
+    },
+    "title": "Google Analytics Content Collector Options",
+    "type": "object",
+    "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/ga-contrib-content-table/query.json
+++ b/stagecraft/apps/collectors/schemas/ga-contrib-content-table/query.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+          "id": {
+              "type": "string",
+              "pattern": "^[a-z0-9:]+$"
+          },
+          "metrics": {
+              "type": "string"
+          },
+          "dimensions": {
+              "type": "array",
+              "items": {
+                  "type": "string"
+              }
+          },
+          "filters": {
+              "type": "array",
+              "items": {
+                  "type": "string"
+              }
+          },
+          "maxResults": {
+              "type": "integer"
+          }
+    },
+    "required": [
+        "metrics"
+    ],
+    "title": "Google Analytics Content Collector Query",
+    "type": "object",
+    "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/ga-realtime/descriptor.json
+++ b/stagecraft/apps/collectors/schemas/ga-realtime/descriptor.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "name": {
+            "type": "string",
+            "pattern": "^[a-z-]+$"
+        },
+        "provider": {
+            "type": "string"
+        },
+        "entry_point": {
+            "type": "string",
+            "pattern": "^[a-z_\\.]+$"
+        }
+    },
+    "title": "Google Analytics Realtime",
+    "type": "object",
+    "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/ga-realtime/options.json
+++ b/stagecraft/apps/collectors/schemas/ga-realtime/options.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {},
+        "title": "Google Analytics Realtime Collector Options",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/ga-realtime/query.json
+++ b/stagecraft/apps/collectors/schemas/ga-realtime/query.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "ids": {
+          "type": "string",
+          "pattern": "^[a-z0-9:]+$"
+        },
+        "metrics": {
+          "type": "string"
+        },
+        "filters": {
+          "type": "string"
+        }
+    },
+    "required": [
+        "metrics"
+    ],
+    "title": "Google Analytics Realtime Collector Query",
+    "type": "object",
+    "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/ga-trending/descriptor.json
+++ b/stagecraft/apps/collectors/schemas/ga-trending/descriptor.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "name": {
+            "type": "string",
+            "pattern": "^[a-z-]+$"
+        },
+        "provider": {
+            "type": "string"
+        },
+        "entry_point": {
+            "type": "string",
+            "pattern": "^[a-z_\\.]+$"
+        }
+    },
+    "title": "Google Analytics Trending",
+    "type": "object",
+    "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/ga-trending/options.json
+++ b/stagecraft/apps/collectors/schemas/ga-trending/options.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {},
+        "title": "Google Analytics Realtime Collector Options",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/ga-trending/query.json
+++ b/stagecraft/apps/collectors/schemas/ga-trending/query.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "ids": {
+            "type": "string",
+            "pattern": "^[a-z0-9:]+$"
+        },
+        "metrics": {
+            "type": "string",
+            "pattern": "^[A-Za-z:]+$"
+        },
+        "filters": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "dimensions": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    },
+    "required": [
+        "metrics"
+    ],
+    "title": "Google Analytics Realtime Collector Query",
+    "type": "object",
+    "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/ga/descriptor.json
+++ b/stagecraft/apps/collectors/schemas/ga/descriptor.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "name": {
+            "type": "string",
+            "pattern": "^[a-z-]+$"
+        },
+        "provider": {
+            "type": "string"
+        },
+        "entry_point": {
+            "type": "string",
+            "pattern": "^[a-z_\\.]+$"
+        }
+    },
+    "title": "Google Analytics",
+    "type": "object",
+    "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/ga/options.json
+++ b/stagecraft/apps/collectors/schemas/ga/options.json
@@ -1,0 +1,162 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "additionalFields": {
+            "type": "object",
+            "properties": {
+                "stage": {
+                    "type": "string"
+                },
+                "eventCategory": {
+                    "type": "string"
+                },
+                "eventAction": {
+                    "type": "string"
+                },
+                "eventType": {
+                    "type": "string"
+                },
+                "eventDetail": {
+                    "type": "string"
+                },
+                "service_identifier": {
+                    "type": "string"
+                },
+                "journey_stage": {
+                    "type": "string"
+                },
+                "event_type": {
+                    "type": "string"
+                },
+                "event_detail": {
+                    "type": "string"
+                },
+                "delivery_stage": {
+                    "type": "string"
+                },
+                "website": {
+                    "type": "string"
+                }
+            }
+        },
+        "mappings": {
+            "type": "object",
+            "properties": {
+                "goal1Completions": {
+                    "type": "string"
+                },
+                "goal1Starts": {
+                    "type": "string"
+                },
+                "goal2Completions": {
+                    "type": "string"
+                },
+                "goal2Starts": {
+                    "type": "string"
+                },
+                "goal3Completions": {
+                    "type": "string"
+                },
+                "goal3Starts": {
+                    "type": "string"
+                },
+                "goal4Completions": {
+                    "type": "string"
+                },
+                "goal4Starts": {
+                    "type": "string"
+                },
+                "goal5Completions": {
+                    "type": "string"
+                },
+                "goal5Starts": {
+                    "type": "string"
+                },
+                "goal6Completions": {
+                    "type": "string"
+                },
+                "goal6Starts": {
+                    "type": "string"
+                },
+                "goal7Completions": {
+                    "type": "string"
+                },
+                "goal7Starts": {
+                    "type": "string"
+                },
+                "goal8Completions": {
+                    "type": "string"
+                },
+                "goal8Starts": {
+                    "type": "string"
+                },
+                "goal9Completions": {
+                    "type": "string"
+                },
+                "goal9Starts": {
+                    "type": "string"
+                },
+                "goal10Completions": {
+                    "type": "string"
+                },
+                "goal10Starts": {
+                    "type": "string"
+                },
+                "goal11Completions": {
+                    "type": "string"
+                },
+                "goal11Starts": {
+                    "type": "string"
+                },
+                "goal12Completions": {
+                    "type": "string"
+                },
+                "goal12Starts": {
+                    "type": "string"
+                },
+                "sessions": {
+                    "type": "string"
+                },
+                "eventLabel": {
+                    "type": "string"
+                },
+                "eventLabel_0": {
+                    "type": "string"
+                },
+                "eventLabel_1": {
+                    "type": "string"
+                },
+                "timeSpan": {
+                    "type": "string"
+                },
+                "pageviews": {
+                    "type": "string"
+                },
+                "searchStartPage": {
+                    "type": "string"
+                }
+            }
+        },
+        "idMapping": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "plugins": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "dataType": {
+            "type": "string"
+        },
+        "chunk-size": {
+            "type": "number"
+        }
+    },
+    "title": "Google Analytics Collector Options",
+    "type": "object",
+    "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/ga/query.json
+++ b/stagecraft/apps/collectors/schemas/ga/query.json
@@ -1,0 +1,56 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9:]+$"
+        },
+        "metrics": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "dimensions": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "sort": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "filters": {
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "string"
+              }
+            ]
+        },
+        "maxResults": {
+            "type": "integer"
+        },
+        "frequency": {
+            "type": "string"
+        },
+        "segment": {
+            "type": "string"
+        }
+
+    },
+    "required": [
+        "metrics"
+    ],
+    "title": "Google Analytics Collector Query",
+    "type": "object",
+    "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/gcloud/descriptor.json
+++ b/stagecraft/apps/collectors/schemas/gcloud/descriptor.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "name": {
+            "type": "string",
+            "pattern": "^[a-z-]+$"
+        },
+        "provider": {
+            "type": "string"
+        },
+        "entry_point": {
+            "type": "string",
+            "pattern": "^[a-z_\\.]+$"
+        }
+    },
+    "title": "GCloud",
+    "type": "object",
+    "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/gcloud/options.json
+++ b/stagecraft/apps/collectors/schemas/gcloud/options.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {},
+        "title": "GCloud Collector Options",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/gcloud/query.json
+++ b/stagecraft/apps/collectors/schemas/gcloud/query.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {},
+        "title": "GCloud Collector Query",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/pingdom/descriptor.json
+++ b/stagecraft/apps/collectors/schemas/pingdom/descriptor.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "name": {
+            "type": "string",
+            "pattern": "^[a-z-]+$"
+        },
+        "provider": {
+            "type": "string"
+        },
+        "entry_point": {
+            "type": "string",
+            "pattern": "^[a-z_\\.]+$"
+        }
+    },
+    "title": "Pingdom",
+    "type": "object",
+    "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/pingdom/options.json
+++ b/stagecraft/apps/collectors/schemas/pingdom/options.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {},
+        "title": "Pingdom Collector Options",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/pingdom/query.json
+++ b/stagecraft/apps/collectors/schemas/pingdom/query.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {
+            "name": {
+                "type": "string"
+            }
+        },
+        "required": [
+            "name"
+        ],
+        "title": "Pingdom Collector Query",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/piwik-core/descriptor.json
+++ b/stagecraft/apps/collectors/schemas/piwik-core/descriptor.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "name": {
+            "type": "string",
+            "pattern": "^[a-z-]+$"
+        },
+        "provider": {
+            "type": "string"
+        },
+        "entry_point": {
+            "type": "string",
+            "pattern": "^[a-z_\\.]+$"
+        }
+    },
+    "title": "Piwik Core",
+    "type": "object",
+    "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/piwik-core/options.json
+++ b/stagecraft/apps/collectors/schemas/piwik-core/options.json
@@ -1,0 +1,51 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {
+            "mappings": {
+                "type": "object",
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    },
+                    "nb_visits": {
+                        "type": "string"
+                    },
+                    "nb_visits_converted": {
+                        "type": "string"
+                    },
+                    "nb_conversions": {
+                        "type": "string"
+                    }
+                }
+            },
+            "idMapping": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "additionalFields": {
+                "service_identifier": {
+                    "type": "string"
+                },
+                "journey_stage": {
+                    "type": "string"
+                },
+                "event_type": {
+                    "type": "string"
+                },
+                "event_detail": {
+                    "type": "string"
+                }
+            },
+            "filters": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "title": "Piwik Core Collector Options",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/piwik-core/query.json
+++ b/stagecraft/apps/collectors/schemas/piwik-core/query.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {
+            "site_id": {
+                "type": "string"
+            },
+            "api_method": {
+                "type": "string"
+            },
+            "frequency": {
+                "type": "string"
+            },
+            "api_method_arguments": {
+                "type": "object",
+                "properties": {
+                    "idGoal": {
+                        "type": "string"
+                    }
+                }
+            },
+            "period": {
+                "type": "string"
+            }
+        },
+        "required": [
+            "site_id"
+        ],
+        "title": "Piwik Core Collector Query",
+        "type": "object",
+        "additionalFields": false
+}

--- a/stagecraft/apps/collectors/schemas/piwik-realtime/descriptor.json
+++ b/stagecraft/apps/collectors/schemas/piwik-realtime/descriptor.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "name": {
+            "type": "string",
+            "pattern": "^[a-z-]+$"
+        },
+        "provider": {
+            "type": "string"
+        },
+        "entry_point": {
+            "type": "string",
+            "pattern": "^[a-z_\\.]+$"
+        }
+    },
+    "title": "Piwik Realtime",
+    "type": "object",
+    "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/piwik-realtime/options.json
+++ b/stagecraft/apps/collectors/schemas/piwik-realtime/options.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {},
+        "title": "Piwik Realtime Collector Options",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/piwik-realtime/query.json
+++ b/stagecraft/apps/collectors/schemas/piwik-realtime/query.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {
+            "site_id": {
+                "type": "string"
+            },
+            "api_method": {
+                "type": "string"
+            },
+            "minutes": {
+                "type": "string",
+                "pattern": "^[0-9]+$"
+            }
+        },
+        "required": [
+            "site_id"
+        ],
+        "title": "Piwik Realtime Collector Query",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/webtrends-keymetrics/descriptor.json
+++ b/stagecraft/apps/collectors/schemas/webtrends-keymetrics/descriptor.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "name": {
+            "type": "string",
+            "pattern": "^[a-z-]+$"
+        },
+        "provider": {
+            "type": "string"
+        },
+        "entry_point": {
+            "type": "string",
+            "pattern": "^[a-z_\\.]+$"
+        }
+    },
+    "title": "Webtrends Keymetrics",
+    "type": "object",
+    "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/webtrends-keymetrics/options.json
+++ b/stagecraft/apps/collectors/schemas/webtrends-keymetrics/options.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {
+            "mappings": {
+                "type": "object",
+                "properties": {
+                    "Visits": {
+                        "type": "string"
+                    },
+                    "Page Views": {
+                        "type": "string"
+                    },
+                    "Visitors": {
+                        "type": "string"
+                    },
+                    "Bounce Rate": {
+                        "type": "string"
+                    },
+                    "Avg. Time on Site": {
+                        "type": "string"
+                    },
+                    "Avg. Visitors per Day": {
+                        "type": "string"
+                    },
+                    "Page Views per Visit": {
+                        "type": "string"
+                    },
+                    "New Visitors": {
+                        "type": "string"
+                    }
+                }
+            },
+            "idMapping": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "title": "Webtrends Keymetrics Collector Options",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/webtrends-keymetrics/query.json
+++ b/stagecraft/apps/collectors/schemas/webtrends-keymetrics/query.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {},
+        "title": "Webtrends Keymetrics Collector Query",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/webtrends-reports/descriptor.json
+++ b/stagecraft/apps/collectors/schemas/webtrends-reports/descriptor.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "name": {
+            "type": "string",
+            "pattern": "^[a-z-]+$"
+        },
+        "provider": {
+            "type": "string"
+        },
+        "entry_point": {
+            "type": "string",
+            "pattern": "^[a-z_\\.]+$"
+        }
+    },
+    "title": "Webtrends Reports",
+    "type": "object",
+    "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/webtrends-reports/options.json
+++ b/stagecraft/apps/collectors/schemas/webtrends-reports/options.json
@@ -1,0 +1,63 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {
+            "additionalFields": {
+                "type": "object",
+                "properties": {
+                    "timeSpan": {
+                        "type": "string"
+                    },
+                    "eventCategory": {
+                        "type": "string"
+                    },
+                    "eventType": {
+                        "type": "string"
+                    },
+                    "eventDetail": {
+                        "type": "string"
+                    }
+                }
+            },
+            "row_type_name": {
+                "type": "string"
+            },
+            "mappings": {
+                "type": "object",
+                "properties": {
+                    "Visits": {
+                        "type": "string"
+                    },
+                    "Page Views": {
+                        "type": "string"
+                    },
+                    "Visitors": {
+                        "type": "string"
+                    },
+                    "Bounce Rate": {
+                        "type": "string"
+                    },
+                    "Avg. Time on Site": {
+                        "type": "string"
+                    },
+                    "Avg. Visitors per Day": {
+                        "type": "string"
+                    },
+                    "Page Views per Visit": {
+                        "type": "string"
+                    },
+                    "New Visitors": {
+                        "type": "string"
+                    }
+                }
+            },
+            "idMapping": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "title": "Webtrends Reports Collector Options",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/webtrends-reports/query.json
+++ b/stagecraft/apps/collectors/schemas/webtrends-reports/query.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {
+            "report_id": {
+                "type": "string"
+            }
+        },
+        "required": [
+            "report_id"
+        ],
+        "title": "Webtrends Reports Collector Query",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/tools/fixtures/test-collector/descriptor.json
+++ b/stagecraft/tools/fixtures/test-collector/descriptor.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "name": {
+            "type": "string",
+            "pattern": "^[a-z-]+$"
+        },
+        "provider": {
+            "type": "string"
+        },
+        "entry_point": {
+            "type": "string",
+            "pattern": "^[a-z_\\.]+$"
+        }
+    },
+    "title": "Test Collector",
+    "type": "object",
+    "additionalProperties": false
+}

--- a/stagecraft/tools/import_collector_types.py
+++ b/stagecraft/tools/import_collector_types.py
@@ -1,0 +1,51 @@
+import os
+import json
+from django.db import IntegrityError
+from stagecraft.apps.collectors.models import CollectorType, Provider
+
+
+def set_collector_type_attributes(collector_type_name, collector_type_schema):
+    collector_type_dict = json.loads(collector_type_schema)
+    entry_point = "performanceplatform.collector." + \
+                  collector_type_name.replace("-", ".")
+    provider_name = collector_type_name.split('-')[0]
+
+    return collector_type_dict["title"], \
+        collector_type_name, \
+        entry_point, \
+        provider_name
+
+
+def create_collector_types(schema_dir=""):
+
+    if not schema_dir:
+        schema_dir = "stagecraft/apps/collectors/schemas"
+
+    for collector_type_name in os.listdir(schema_dir):
+        collector_type_dir = schema_dir + "/" + collector_type_name
+
+        if os.path.isdir(collector_type_dir):
+            query_schema = open(collector_type_dir + "/query.json").read()
+            options_schema = open(collector_type_dir + "/options.json").read()
+            collector_type_schema = open(
+                collector_type_dir + "/descriptor.json").read()
+
+            name, slug, entry_point, provider_name = \
+                set_collector_type_attributes(collector_type_name,
+                                              collector_type_schema)
+
+            provider, _ = Provider.objects.get_or_create(name=provider_name)
+
+            try:
+                CollectorType.objects.create(name=name,
+                                             slug=slug,
+                                             provider=provider,
+                                             entry_point=entry_point,
+                                             query_schema=query_schema,
+                                             options_schema=options_schema)
+            except IntegrityError:
+                continue
+
+
+if __name__ == "__main__":
+    create_collector_types()

--- a/stagecraft/tools/tests/test_import_collector_types.py
+++ b/stagecraft/tools/tests/test_import_collector_types.py
@@ -1,0 +1,23 @@
+from django.utils import unittest
+from nose.tools import assert_equal
+from stagecraft.apps.collectors.models import CollectorType
+from stagecraft.tools.import_collector_types import create_collector_types, \
+    set_collector_type_attributes
+
+
+class ImportCollectorTypesTest(unittest.TestCase):
+
+    def test_attributes_from_schema(self):
+
+        collector_type_schema = open(
+            'stagecraft/tools/fixtures/test-collector/descriptor.json').read()
+
+        name, slug, entry_point, provider_name = \
+            set_collector_type_attributes("test-collector",
+                                          collector_type_schema)
+
+        assert_equal(name, "Test Collector")
+        assert_equal(slug, "test-collector")
+        assert_equal(entry_point,
+                     "performanceplatform.collector.test.collector")
+        assert_equal(provider_name, "test")


### PR DESCRIPTION
Create collector type schemas
=======================
1. Add schemas for the different types of collector.
Each collector type needs three schemas:
  * query.json - used to validate the query parameters of the collector
  * options.json - used the validate the optional parameters of the collector
  * descriptor.json - describes the properties required to create a collector type.
Used by the import_collector_types script to extract properties e.g. The title in the
descriptor schema will become the human readable name of the collector type.

2. Every collector type should have a query, options, and descriptor schema.
Even if a collector type doesn't allow for a query and/or options object, a
schema with empty properties has been added to be able to validate that no
properties can be passed in.

3. All of the schemas have additionalProperties set to false so that we can
catch any collector type attributes that may have been missed when the
collectors are imported.

Script to create collector types
=======================
The folder names that contain the schemas for a collector type follow a pattern.
If the collector in performanceplatform-collector can be found in
performanceplatform/collector/ga/trending then the folder name for the schemas should
be 'ga-trending'

The collector type slug is determined by the name of the folder containing
the schemas for the collector type. e.g in the example above the collector type slug
is 'ga-trending'

The provider is determined by trying to match the name to the first part of
collector type slug. e.g. if the slug is 'ga-trending', the provider name is 'ga'.
The provider is created if it doesn't already exist.

Provider creation should be revisited to perhaps add a slug to the Provider and base Provider
selection on the value of the slug.

Story in Pivotal: https://www.pivotaltracker.com/story/show/98935306