### PR TITLE
Import collector data

### DIFF
--- a/stagecraft/apps/collectors/management/commands/import_collector_config.py
+++ b/stagecraft/apps/collectors/management/commands/import_collector_config.py
@@ -1,0 +1,178 @@
+from __future__ import print_function
+
+import json
+import functools
+import hashlib
+import os
+
+from collections import defaultdict
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from stagecraft.apps.collectors.models import (
+    Collector, CollectorType, DataSource, Provider
+)
+from stagecraft.apps.datasets.models import DataSet
+
+
+entrypoint_information = {
+    'performanceplatform.collector.ga': {
+        'credentials': 'ga-performanceplatform',
+        'repeat': 'daily',
+    },
+    'performanceplatform.collector.webtrends.reports': {
+        'credentials': {
+            'nas-applications': 'webtrends-national-apprenticeship-scheme',
+            'nhs-choices': 'webtrends-nhs-choices',
+        },
+        'repeat': 'daily',
+    },
+    'performanceplatform.collector.webtrends.keymetrics': {
+        'credentials': {
+            'nas-applications': 'webtrends-national-apprenticeship-scheme',
+            'nhs-choices': 'webtrends-nhs-choices',
+        },
+        'repeat': 'hourly',
+    },
+    'performanceplatform.collector.ga.trending': {
+        'credentials': 'ga-performanceplatform',
+        'repeat': 'daily',
+    },
+    'performanceplatform.collector.ga.contrib.content.table': {
+        'credentials': 'ga-performanceplatform',
+        'repeat': 'daily',
+    },
+    'performanceplatform.collector.ga.realtime': {
+        'credentials': 'ga-performanceplatform',
+        'repeat': '2minute',
+    },
+    'performanceplatform.collector.pingdom': {
+        'credentials': 'pingdom-performanceplatform',
+        'repeat': 'hourly',
+    },
+    'performanceplatform.collector.piwik.core': {
+        'credentials': 'piwik-fco',
+        'repeat': 'daily',
+    },
+    'performanceplatform.collector.piwik.realtime': {
+        'credentials': 'piwik-fco',
+        'repeat': '2minute',
+    },
+    'performanceplatform.collector.gcloud': {
+        'credentials': 'gcloud',
+        'repeat': 'hourly',
+    },
+}
+
+
+class Command(BaseCommand):
+    args = '<config_dir>'
+    help = 'Import collector configuration from repo.'
+
+    def handle(self, *args, **options):
+        if not len(args):
+            raise CommandError('No config directory given')
+
+        queries_dir = os.path.join(args[0], 'queries')
+        config = self.load_config(queries_dir)
+        by_slug = self.sort_by_slug(config)
+
+        with transaction.atomic():
+            self.delete_generated_collectors()
+            self.import_config(by_slug)
+
+    def delete_generated_collectors(self):
+        Collector.objects.filter(slug__iregex=r'^.+-[0-9a-f]{8}$').delete()
+
+    def import_config(self, by_slug):
+        for slug, config in by_slug.items():
+            data_group = config['data-set']['data-group']
+            try:
+                data_set = DataSet.objects.get(
+                    data_group__name=data_group,
+                    data_type__name=config['data-set']['data-type'],
+                )
+            except DataSet.DoesNotExist:
+                data_set = None
+
+            collector_type = CollectorType.objects.get(
+                entry_point=config['entrypoint'],
+            )
+
+            query_info = entrypoint_information[config['entrypoint']]
+
+            data_source_slug = query_info['credentials']
+            if type(data_source_slug) == dict:
+                data_source_slug = data_source_slug[data_group]
+
+            data_source = DataSource.objects.get(
+                slug=data_source_slug,
+            )
+
+            if data_set:
+                collector = Collector(
+                    slug=slug,
+                    type=collector_type,
+                    data_source=data_source,
+                    data_set=data_set,
+                    query=config['query'],
+                    options=config['options'],
+                )
+
+                validation = collector.validate()
+                if validation is not None:
+                    raise CommandError(
+                        '{}: {}'.format(slug, validation)
+                    )
+
+                collector.save()
+
+    def sort_by_slug(self, configs):
+        by_slug = defaultdict(list)
+        for config in configs:
+            slug = '{}-{}-{}'.format(
+                config['data-set']['data-group'],
+                config['data-set']['data-type'],
+                self.hash_dicts(config['query'], config['options'])
+            )
+            by_slug[slug].append(config)
+
+        for slug, configs in by_slug.items():
+            if len(configs) > 1:
+                raise CommandError(
+                    '{} has more than one config'.format(slug)
+                )
+            by_slug[slug] = configs[0]
+
+        return by_slug
+
+    def hash_dicts(self, *dicts):
+        dicts_as_strings = map(json.dumps, dicts)
+        return hashlib \
+            .sha512(''.join(dicts_as_strings)) \
+            .hexdigest()[:8]
+
+    def load_config(self, directory):
+        configs = []
+
+        for root, dirs, files in os.walk(directory):
+            for config_file in files:
+                config = self.parse_config(
+                    os.path.join(root, config_file)
+                )
+
+                if config is not None:
+                    configs.append(config)
+
+        return configs
+
+    def parse_config(self, path):
+        with open(path, 'r') as config_file:
+            try:
+                config = json.load(config_file)
+            except ValueError as err:
+                print('Error parsing {}: {}'.format(path, err))
+                config = None
+
+        return config

--- a/stagecraft/apps/collectors/management/commands/import_schemata.py
+++ b/stagecraft/apps/collectors/management/commands/import_schemata.py
@@ -1,0 +1,66 @@
+from __future__ import print_function
+
+import json
+import os
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from stagecraft.apps.collectors.models import CollectorType
+
+
+class Command(BaseCommand):
+    args = '<schemas_dir>'
+    help = 'Import schemas for collectors app'
+
+    def handle(self, *args, **options):
+        if not len(args):
+            raise CommandError('No schema directory given')
+
+        collector_type_schemas = self.load_schemas(
+            os.path.join(args[0], 'collector-type'),
+        )
+
+        with transaction.atomic():
+            for slug, schemas in collector_type_schemas.items():
+                collector_type = CollectorType.objects.get(slug=slug)
+                collector_type.query_schema = schemas['query.json']
+                collector_type.options_schema = schemas['options.json']
+
+                print('Validating and saving type {}'.format(slug))
+
+                validation = collector_type.validate()
+                if validation is not None:
+                    raise CommandError(
+                        '{}: {}'.format(slug, validation)
+                    )
+
+                collector_type.save()
+
+                print('Validating all collectors of type {}'.format(slug))
+
+                for collector in collector_type.collector_set.all():
+                    validation = collector.validate()
+                    if validation is not None:
+                        raise CommandError(
+                            '{}: {}'.format(collector.slug, validation)
+                        )
+
+    def load_schemas(self, path):
+        schemas = {}
+        for schema_file in os.listdir(path):
+            schema_path = os.path.join(path, schema_file)
+
+            if os.path.isdir(schema_path):
+                schema = self.load_schemas(schema_path)
+            else:
+                with open(schema_path, 'r') as schema_fd:
+                    try:
+                        schema = json.load(schema_fd)
+                    except ValueError as err:
+                        print('Error parsing {}: {}'.format(path, err))
+                        schema = None
+
+            schemas[schema_file] = schema
+
+        return schemas

--- a/stagecraft/apps/collectors/migrations/0002_auto_20150730_1328.py
+++ b/stagecraft/apps/collectors/migrations/0002_auto_20150730_1328.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('collectors', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='collector',
+            name='slug',
+            field=models.SlugField(default='', unique=True, max_length=100),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='collectortype',
+            name='slug',
+            field=models.SlugField(default='', unique=True, max_length=100),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='datasource',
+            name='slug',
+            field=models.SlugField(default='', unique=True, max_length=100),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='provider',
+            name='slug',
+            field=models.SlugField(default='', unique=True, max_length=100),
+            preserve_default=False,
+        ),
+    ]

--- a/stagecraft/apps/collectors/migrations/0003_auto_20150730_1329.py
+++ b/stagecraft/apps/collectors/migrations/0003_auto_20150730_1329.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+providers = {
+    'ga': {
+        'name': 'Google Analytics',
+        'data_sources': {
+            'ga-performanceplatform': {
+                'name': 'GA Performance Platform',
+            },
+        },
+        'collector_types': {
+            'ga': {
+                'name': 'Google Analytics',
+                'entry_point': 'performanceplatform.collector.ga',
+            },
+            'ga-realtime': {
+                'name': 'Google Analytics Realtime',
+                'entry_point': 'performanceplatform.collector.ga.realtime',
+            },
+            'ga-trending': {
+                'name': 'Google Analytics Trending',
+                'entry_point': 'performanceplatform.collector.ga.trending',
+            },
+            'ga-contrib-content-table': {
+                'name': 'Google Analytics Content Table',
+                'entry_point': 'performanceplatform.collector.ga.contrib.content.table',
+            }
+        }
+    },
+    'pingdom': {
+        'name': 'Pingdom',
+        'data_sources': {
+            'pingdom-performanceplatform': {
+                'name': 'Pingdom Performance Platform',
+            },
+        },
+        'collector_types':{
+            'pingdom': {
+                'name': 'Pingdom',
+                'entry_point': 'performanceplatform.collector.pingdom',
+            },
+        },
+    },
+    'webtrends': {
+        'name': 'Webtrends',
+        'data_sources': {
+            'webtrends-nhs-choices': {
+                'name': 'Webtrends NHS Choices',
+            },
+            'webtrends-national-apprenticeship-scheme': {
+                'name': 'Webtrends National Apprenticeships Scheme',
+            },
+        },
+        'collector_types':{
+            'webtrends-reports': {
+                'name': 'Webtrends Reports',
+                'entry_point': 'performanceplatform.collector.webtrends.reports',
+            },
+            'webtrends-keymetrics': {
+                'name': 'Webtrends Keymetrics',
+                'entry_point': 'performanceplatform.collector.webtrends.keymetrics',
+            },
+        },
+    },
+    'piwik': {
+        'name': 'Piwik',
+        'data_sources': {
+            'piwik-fco': {
+                'name': 'Piwik FCO',
+            },
+            'piwik-verify': {
+                'name': 'Piwik Verify',
+            },
+        },
+        'collector_types':{
+            'piwik-core': {
+                'name': 'Piwik',
+                'entry_point': 'performanceplatform.collector.piwik.core',
+            },
+            'piwik-realtime': {
+                'name': 'Piwik Realtime',
+                'entry_point': 'performanceplatform.collector.piwik.realtime',
+            },
+        },
+    },
+    'gcloud': {
+        'name': 'gcloud',
+        'data_sources': {
+            'gcloud': {
+                'name': 'GCloud',
+            },
+        },
+        'collector_types':{
+            'gcloud': {
+                'name': 'G-Cloud',
+                'entry_point': 'performanceplatform.collector.gcloud',
+            },
+        },
+    },
+}
+
+
+def add_base_data(apps, schema_editor):
+    Provider = apps.get_model('collectors', 'Provider')
+    DataSource = apps.get_model('collectors', 'DataSource')
+    CollectorType = apps.get_model('collectors', 'CollectorType')
+
+    for provider_slug, provider_def in providers.items():
+        provider = Provider.objects.create(
+            slug=provider_slug,
+            name=provider_def['name'],
+        )
+
+        for data_source_slug, data_source_def in provider_def['data_sources'].items():
+            data_source = DataSource.objects.create(
+                slug=data_source_slug,
+                name=data_source_def['name'],
+                provider=provider,
+            )
+
+        for collector_type_slug, collector_type_def in provider_def['collector_types'].items():
+            collector_type = CollectorType.objects.create(
+                slug=collector_type_slug,
+                name=collector_type_def['name'],
+                provider=provider,
+                entry_point=collector_type_def['entry_point'],
+            )
+
+
+def remove_base_data(apps, schema_editor):
+    Provider = apps.get_model('collectors', 'Provider')
+    DataSource = apps.get_model('collectors', 'DataSource')
+    CollectorType = apps.get_model('collectors', 'CollectorType')
+
+    for provider_slug, provider_def in providers.items():
+        Provider.objects.filter(slug=provider_slug).delete()
+
+        for data_source_slug, _ in provider_def['data_sources'].items():
+            DataSource.objects.filter(slug=data_source_slug).delete()
+
+        for collector_type_slug, _ in provider_def['collector_types'].items():
+            CollectorType.objects.filter(slug=collector_type_slug).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('collectors', '0002_auto_20150730_1328'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_base_data, remove_base_data)
+    ]

--- a/stagecraft/apps/collectors/models.py
+++ b/stagecraft/apps/collectors/models.py
@@ -19,7 +19,7 @@ class Provider(models.Model):
 
     def validate(self):
         try:
-            jsonschema.Draft3Validator.check_schema(self.credentials_schema)
+            jsonschema.Draft4Validator.check_schema(self.credentials_schema)
         except jsonschema.SchemaError as err:
             return 'schema is invalid: {}'.format(err)
 
@@ -96,12 +96,12 @@ class CollectorType(models.Model):
 
     def validate(self):
         try:
-            jsonschema.Draft3Validator.check_schema(self.query_schema)
+            jsonschema.Draft4Validator.check_schema(self.query_schema)
         except jsonschema.SchemaError as err:
             return 'query schema is invalid: {}'.format(err)
 
         try:
-            jsonschema.Draft3Validator.check_schema(self.options_schema)
+            jsonschema.Draft4Validator.check_schema(self.options_schema)
         except jsonschema.SchemaError as err:
             return 'options schema is invalid: {}'.format(err)
 

--- a/stagecraft/apps/collectors/models.py
+++ b/stagecraft/apps/collectors/models.py
@@ -12,6 +12,7 @@ from stagecraft.apps.users.models import User
 
 class Provider(models.Model):
     id = models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True)
+    slug = models.SlugField(max_length=100, unique=True)
     name = models.CharField(max_length=256, unique=True)
 
     credentials_schema = JSONField(default={}, blank=True)
@@ -37,6 +38,7 @@ class Provider(models.Model):
 
 class DataSource(models.Model):
     id = models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True)
+    slug = models.SlugField(max_length=100, unique=True)
     name = models.CharField(max_length=256, unique=True)
 
     provider = models.ForeignKey(Provider)
@@ -72,6 +74,7 @@ class DataSource(models.Model):
 
 class CollectorType(models.Model):
     id = models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True)
+    slug = models.SlugField(max_length=100, unique=True)
     name = models.CharField(max_length=256, unique=True)
 
     provider = models.ForeignKey(Provider)
@@ -117,6 +120,7 @@ class CollectorType(models.Model):
 
 class Collector(models.Model):
     id = models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True)
+    slug = models.SlugField(max_length=100, unique=True)
 
     type = models.ForeignKey(CollectorType)
     collector_choices = ('test', 'test')

--- a/stagecraft/apps/collectors/schemas/collector-type/ga-contrib-content-table/options.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/ga-contrib-content-table/options.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "plugins": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "filtersets": {
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        }
+    },
+    "title": "Google Analytics Content Collector Options",
+    "type": "object",
+    "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/collector-type/ga-contrib-content-table/query.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/ga-contrib-content-table/query.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+          "id": {
+              "type": "string",
+              "pattern": "^[a-z0-9:]+$"
+          },
+          "metrics": {
+              "oneOf": [
+                  { "type": "string" },
+                  {
+                      "type": "array",
+                      "items": {
+                          "type": "string"
+                      }
+                  }
+              ]
+          },
+          "dimensions": {
+              "type": "array",
+              "items": {
+                  "type": "string"
+              }
+          },
+          "filters": {
+              "type": "array",
+              "items": {
+                  "type": "string"
+              }
+          },
+          "sort": {
+              "type": "array",
+              "items": {
+                  "type": "string"
+              }
+          },
+          "maxResults": {
+              "type": "integer"
+          }
+    },
+    "required": [
+        "metrics"
+    ],
+    "title": "Google Analytics Content Collector Query",
+    "type": "object",
+    "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/collector-type/ga-realtime/options.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/ga-realtime/options.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {},
+        "title": "Google Analytics Realtime Collector Options",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/collector-type/ga-realtime/query.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/ga-realtime/query.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "ids": {
+          "type": "string",
+          "pattern": "^[a-z0-9:]+$"
+        },
+        "metrics": {
+          "type": "string"
+        },
+        "filters": {
+          "type": "string"
+        }
+    },
+    "required": [
+        "metrics"
+    ],
+    "title": "Google Analytics Realtime Collector Query",
+    "type": "object",
+    "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/collector-type/ga-trending/options.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/ga-trending/options.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {},
+        "title": "Google Analytics Trending Collector Options",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/collector-type/ga-trending/query.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/ga-trending/query.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "id": {
+            "type": "string",
+            "pattern": "^[a-z0-9:]+$"
+        },
+        "metric": {
+            "type": "string",
+            "pattern": "^[A-Za-z:]+$"
+        },
+        "filters": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "dimensions": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    },
+    "required": [
+        "metric"
+    ],
+    "title": "Google Analytics Trending Collector Query",
+    "type": "object",
+    "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/collector-type/ga/options.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/ga/options.json
@@ -1,0 +1,162 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "additionalFields": {
+            "type": "object",
+            "properties": {
+                "stage": {
+                    "type": "string"
+                },
+                "eventCategory": {
+                    "type": "string"
+                },
+                "eventAction": {
+                    "type": "string"
+                },
+                "eventType": {
+                    "type": "string"
+                },
+                "eventDetail": {
+                    "type": "string"
+                },
+                "service_identifier": {
+                    "type": "string"
+                },
+                "journey_stage": {
+                    "type": "string"
+                },
+                "event_type": {
+                    "type": "string"
+                },
+                "event_detail": {
+                    "type": "string"
+                },
+                "delivery_stage": {
+                    "type": "string"
+                },
+                "website": {
+                    "type": "string"
+                }
+            }
+        },
+        "mappings": {
+            "type": "object",
+            "properties": {
+                "goal1Completions": {
+                    "type": "string"
+                },
+                "goal1Starts": {
+                    "type": "string"
+                },
+                "goal2Completions": {
+                    "type": "string"
+                },
+                "goal2Starts": {
+                    "type": "string"
+                },
+                "goal3Completions": {
+                    "type": "string"
+                },
+                "goal3Starts": {
+                    "type": "string"
+                },
+                "goal4Completions": {
+                    "type": "string"
+                },
+                "goal4Starts": {
+                    "type": "string"
+                },
+                "goal5Completions": {
+                    "type": "string"
+                },
+                "goal5Starts": {
+                    "type": "string"
+                },
+                "goal6Completions": {
+                    "type": "string"
+                },
+                "goal6Starts": {
+                    "type": "string"
+                },
+                "goal7Completions": {
+                    "type": "string"
+                },
+                "goal7Starts": {
+                    "type": "string"
+                },
+                "goal8Completions": {
+                    "type": "string"
+                },
+                "goal8Starts": {
+                    "type": "string"
+                },
+                "goal9Completions": {
+                    "type": "string"
+                },
+                "goal9Starts": {
+                    "type": "string"
+                },
+                "goal10Completions": {
+                    "type": "string"
+                },
+                "goal10Starts": {
+                    "type": "string"
+                },
+                "goal11Completions": {
+                    "type": "string"
+                },
+                "goal11Starts": {
+                    "type": "string"
+                },
+                "goal12Completions": {
+                    "type": "string"
+                },
+                "goal12Starts": {
+                    "type": "string"
+                },
+                "sessions": {
+                    "type": "string"
+                },
+                "eventLabel": {
+                    "type": "string"
+                },
+                "eventLabel_0": {
+                    "type": "string"
+                },
+                "eventLabel_1": {
+                    "type": "string"
+                },
+                "timeSpan": {
+                    "type": "string"
+                },
+                "pageviews": {
+                    "type": "string"
+                },
+                "searchStartPage": {
+                    "type": "string"
+                }
+            }
+        },
+        "idMapping": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "plugins": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "dataType": {
+            "type": "string"
+        },
+        "chunk-size": {
+            "type": "number"
+        }
+    },
+    "title": "Google Analytics Collector Options",
+    "type": "object",
+    "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/collector-type/ga/query.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/ga/query.json
@@ -1,0 +1,56 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9:]+$"
+        },
+        "metrics": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "dimensions": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "sort": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "filters": {
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "string"
+              }
+            ]
+        },
+        "maxResults": {
+            "type": "integer"
+        },
+        "frequency": {
+            "type": "string"
+        },
+        "segment": {
+            "type": "string"
+        }
+
+    },
+    "required": [
+        "metrics"
+    ],
+    "title": "Google Analytics Collector Query",
+    "type": "object",
+    "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/collector-type/gcloud/options.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/gcloud/options.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {},
+        "title": "GCloud Collector Options",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/collector-type/gcloud/query.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/gcloud/query.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {},
+        "title": "GCloud Collector Query",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/collector-type/pingdom/options.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/pingdom/options.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {},
+        "title": "Pingdom Collector Options",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/collector-type/pingdom/query.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/pingdom/query.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {
+            "name": {
+                "type": "string"
+            }
+        },
+        "required": [
+            "name"
+        ],
+        "title": "Pingdom Collector Query",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/collector-type/piwik-core/options.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/piwik-core/options.json
@@ -1,0 +1,51 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {
+            "mappings": {
+                "type": "object",
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    },
+                    "nb_visits": {
+                        "type": "string"
+                    },
+                    "nb_visits_converted": {
+                        "type": "string"
+                    },
+                    "nb_conversions": {
+                        "type": "string"
+                    }
+                }
+            },
+            "idMapping": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "additionalFields": {
+                "service_identifier": {
+                    "type": "string"
+                },
+                "journey_stage": {
+                    "type": "string"
+                },
+                "event_type": {
+                    "type": "string"
+                },
+                "event_detail": {
+                    "type": "string"
+                }
+            },
+            "filters": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "title": "Piwik Core Collector Options",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/collector-type/piwik-core/query.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/piwik-core/query.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {
+            "site_id": {
+                "type": "string"
+            },
+            "api_method": {
+                "type": "string"
+            },
+            "frequency": {
+                "type": "string"
+            },
+            "api_method_arguments": {
+                "type": "object",
+                "properties": {
+                    "idGoal": {
+                        "type": "string"
+                    }
+                }
+            },
+            "period": {
+                "type": "string"
+            }
+        },
+        "required": [
+            "site_id"
+        ],
+        "title": "Piwik Core Collector Query",
+        "type": "object",
+        "additionalFields": false
+}

--- a/stagecraft/apps/collectors/schemas/collector-type/piwik-realtime/options.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/piwik-realtime/options.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {},
+        "title": "Piwik Realtime Collector Options",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/collector-type/piwik-realtime/query.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/piwik-realtime/query.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {
+            "site_id": {
+                "type": "string"
+            },
+            "api_method": {
+                "type": "string"
+            },
+            "minutes": {
+                "type": "string",
+                "pattern": "^[0-9]+$"
+            }
+        },
+        "required": [
+            "site_id"
+        ],
+        "title": "Piwik Realtime Collector Query",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/collector-type/webtrends-keymetrics/options.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/webtrends-keymetrics/options.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {
+            "additionalFields": {
+                "type": "object"
+            },
+            "mappings": {
+                "type": "object"
+            },
+            "idMapping": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "row_type_name": {
+                "type": "string"
+            }
+        },
+        "title": "Webtrends Keymetrics Collector Options",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/collector-type/webtrends-keymetrics/query.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/webtrends-keymetrics/query.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {},
+        "title": "Webtrends Keymetrics Collector Query",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/collector-type/webtrends-reports/options.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/webtrends-reports/options.json
@@ -1,0 +1,63 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {
+            "additionalFields": {
+                "type": "object",
+                "properties": {
+                    "timeSpan": {
+                        "type": "string"
+                    },
+                    "eventCategory": {
+                        "type": "string"
+                    },
+                    "eventType": {
+                        "type": "string"
+                    },
+                    "eventDetail": {
+                        "type": "string"
+                    }
+                }
+            },
+            "row_type_name": {
+                "type": "string"
+            },
+            "mappings": {
+                "type": "object",
+                "properties": {
+                    "Visits": {
+                        "type": "string"
+                    },
+                    "Page Views": {
+                        "type": "string"
+                    },
+                    "Visitors": {
+                        "type": "string"
+                    },
+                    "Bounce Rate": {
+                        "type": "string"
+                    },
+                    "Avg. Time on Site": {
+                        "type": "string"
+                    },
+                    "Avg. Visitors per Day": {
+                        "type": "string"
+                    },
+                    "Page Views per Visit": {
+                        "type": "string"
+                    },
+                    "New Visitors": {
+                        "type": "string"
+                    }
+                }
+            },
+            "idMapping": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "title": "Webtrends Reports Collector Options",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/schemas/collector-type/webtrends-reports/query.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/webtrends-reports/query.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+        "properties": {
+            "report_id": {
+                "type": "string"
+            }
+        },
+        "required": [
+            "report_id"
+        ],
+        "title": "Webtrends Reports Collector Query",
+        "type": "object",
+        "additionalProperties": false
+}

--- a/stagecraft/apps/collectors/tests/factories.py
+++ b/stagecraft/apps/collectors/tests/factories.py
@@ -13,6 +13,7 @@ class ProviderFactory(factory.DjangoModelFactory):
         model = Provider
         django_get_or_create = ('name',)
     name = factory.Sequence(lambda n: 'provider-%s' % n)
+    slug = factory.Sequence(lambda n: 'provider-%s' % n)
 
 
 class CollectorTypeFactory(factory.DjangoModelFactory):
@@ -21,6 +22,7 @@ class CollectorTypeFactory(factory.DjangoModelFactory):
         model = CollectorType
 
     name = factory.Sequence(lambda n: 'collector-type-%s' % n)
+    slug = factory.Sequence(lambda n: 'collector-type-%s' % n)
     provider = factory.SubFactory(ProviderFactory)
     entry_point = factory.Sequence(lambda n: 'entry_point_%s' % n)
 
@@ -31,6 +33,7 @@ class DataSourceFactory(factory.DjangoModelFactory):
         model = DataSource
         django_get_or_create = ('name',)
     name = factory.Sequence(lambda n: 'data-source-%s' % n)
+    slug = factory.Sequence(lambda n: 'data-source-%s' % n)
     provider = factory.SubFactory(ProviderFactory)
 
 
@@ -39,6 +42,7 @@ class CollectorFactory(factory.DjangoModelFactory):
     class Meta:
         model = Collector
 
+    slug = factory.Sequence(lambda n: 'collector-%s' % n)
     type = factory.SubFactory(CollectorTypeFactory)
     data_source = factory.SubFactory(
         DataSourceFactory, provider=factory.SelfAttribute('..type.provider'))


### PR DESCRIPTION
This sets up a migration for base data (providers, data sources and collector types) then adds a couple of management commands for importing collector type schemas and collector configuration.

Supersedes #399 

This requires https://github.com/alphagov/performanceplatform-collector-config/pull/212 is merged so that the collectors don't fail the schema validation