### PR TITLE
Expose collector models (configuration) via an API

### DIFF
--- a/stagecraft/apps/collectors/tests/test_views.py
+++ b/stagecraft/apps/collectors/tests/test_views.py
@@ -1,0 +1,487 @@
+import json
+import uuid
+from django.test import TestCase
+from hamcrest import assert_that, equal_to, has_key, has_entries, \
+    match_equality
+from stagecraft.apps.collectors.tests.factories import ProviderFactory, \
+    DataSourceFactory, CollectorTypeFactory, CollectorFactory
+from stagecraft.apps.datasets.tests.factories import DataSetFactory
+from stagecraft.libs.backdrop_client import disable_backdrop_connection
+from stagecraft.libs.views.utils import to_json
+
+
+class ProviderViewTestCase(TestCase):
+
+    def test_get(self):
+        provider = ProviderFactory(
+            credentials_schema={
+                "$schema": "http://json-schema.org/schema#",
+                "type": "object",
+                "properties": {
+                    "password": {"type": "string"},
+                },
+                "required": ["password"],
+                "additionalProperties": False,
+            })
+        response = self.client.get(
+            '/provider/{}'.format(provider.name),
+            HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
+            content_type='application/json')
+
+        assert_that(response.status_code, equal_to(200))
+
+        resp_json = json.loads(response.content)
+
+        assert_that(resp_json['id'], equal_to(str(provider.id)))
+        assert_that(resp_json['name'], equal_to(provider.name))
+        assert_that(resp_json['credentials_schema'], equal_to(
+            provider.credentials_schema))
+
+    def test_get_from_unauthorised_client_fails(self):
+        provider = ProviderFactory()
+        resp = self.client.get(
+            '/provider/{}'.format(provider.name))
+
+        assert_that(resp.status_code, equal_to(403))
+
+    def test_post(self):
+        provider = {
+            "name": "some-provider",
+            "slug": "some-provider"
+        }
+
+        resp = self.client.post(
+            '/provider',
+            data=json.dumps(provider),
+            HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
+            content_type='application/json')
+
+        assert_that(resp.status_code, equal_to(200))
+
+        resp_json = json.loads(resp.content)
+
+        assert_that(resp_json, has_key('id'))
+        assert_that(resp_json['name'], equal_to('some-provider'))
+        assert_that(resp_json['slug'], equal_to('some-provider'))
+
+    def test_post_from_unauthorised_client_fails(self):
+        provider = {
+            'name': 'some-provider',
+            "slug": "some-provider"
+        }
+        resp = self.client.post(
+            '/provider',
+            data=json.dumps(provider),
+            content_type='application/json')
+
+        assert_that(resp.status_code, equal_to(403))
+
+
+class DataSourceViewTestCase(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.provider = ProviderFactory()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.provider.delete()
+
+    def test_get(self):
+        data_source = DataSourceFactory()
+        response = self.client.get(
+            '/data-source/{}'.format(data_source.name),
+            HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
+            content_type='application/json')
+
+        assert_that(response.status_code, equal_to(200))
+
+        resp_json = json.loads(response.content)
+
+        assert_that(resp_json['id'], equal_to(str(data_source.id)))
+        assert_that(resp_json['name'], equal_to(data_source.name))
+        assert_that(
+            resp_json['provider']['name'], equal_to(data_source.provider.name))
+        assert_that(resp_json, not(has_key('credentials')))
+
+    def test_get_from_unauthorised_client_fails(self):
+        data_source = DataSourceFactory()
+        resp = self.client.get(
+            '/data-source/{}'.format(data_source.name))
+
+        assert_that(resp.status_code, equal_to(403))
+
+    def test_post(self):
+        data_source = {
+            "name": "some-data-source",
+            "slug": "some-data-source",
+            "provider_id": self.provider.id
+        }
+
+        resp = self.client.post(
+            '/data-source',
+            data=to_json(data_source),
+            HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
+            content_type='application/json')
+
+        assert_that(resp.status_code, equal_to(200))
+
+        resp_json = json.loads(resp.content)
+
+        assert_that(resp_json, has_key('id'))
+        assert_that(resp_json['name'], equal_to('some-data-source'))
+        assert_that(resp_json['slug'], equal_to('some-data-source'))
+        assert_that(resp_json['provider']['name'], equal_to(
+            self.provider.name))
+
+    def test_post_from_unauthorised_client_fails(self):
+        data_source = {
+            "name": "some-data-source",
+            "slug": "some-data-source",
+            "provider": self.provider.id
+        }
+        resp = self.client.post(
+            '/data-source',
+            data=to_json(data_source),
+            content_type='application/json')
+
+        assert_that(resp.status_code, equal_to(403))
+
+    def test_post_with_non_existent_provider_fails(self):
+        provider = uuid.UUID('01234a12-1234-1234-5b6c-0de12e3a4f15')
+        data_source = {
+            'name': 'some-data-source',
+            'slug': 'some-data-source',
+            'provider_id': provider
+        }
+        response = self.client.post(
+            '/data-source',
+            data=to_json(data_source),
+            HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
+            content_type='application/json')
+
+        assert_that(response.status_code, equal_to(400))
+
+        resp_json = json.loads(response.content)
+        assert_that(resp_json['message'], equal_to(
+            "No provider with id '{}' found".format(provider)))
+
+
+class CollectorTypeViewTestCase(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.provider = ProviderFactory()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.provider.delete()
+
+    def test_get(self):
+        collector_type = CollectorTypeFactory(
+            query_schema={
+                "$schema": "A Schema",
+            },
+            options_schema={
+                "$schema": "A Schema",
+            }
+        )
+        response = self.client.get(
+            '/collector-type/{}'.format(collector_type.name),
+            HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
+            content_type='application/json')
+
+        assert_that(response.status_code, equal_to(200))
+
+        resp_json = json.loads(response.content)
+
+        assert_that(resp_json['id'], equal_to(str(collector_type.id)))
+        assert_that(resp_json['slug'], equal_to(collector_type.slug))
+        assert_that(resp_json['name'], equal_to(collector_type.name))
+        assert_that(resp_json['entry_point'], equal_to(
+            collector_type.entry_point))
+        assert_that(resp_json['provider']['name'], equal_to(
+            collector_type.provider.name))
+        assert_that(resp_json['query_schema'], equal_to(
+            collector_type.query_schema))
+        assert_that(resp_json['options_schema'], equal_to(
+            collector_type.options_schema))
+
+    def test_get_from_unauthorised_client_fails(self):
+        collector_type = CollectorTypeFactory()
+        resp = self.client.get(
+            '/collector-type/{}'.format(collector_type.name))
+
+        assert_that(resp.status_code, equal_to(403))
+
+    def test_list(self):
+        collector_type_1 = CollectorTypeFactory()
+        collector_type_2 = CollectorTypeFactory()
+
+        response = self.client.get(
+            '/collector-type',
+            HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
+            content_type='application/json')
+
+        assert_that(response.status_code, equal_to(200))
+
+        resp_json = json.loads(response.content)
+
+        assert_that(resp_json, match_equality(
+            has_entries({"slug": collector_type_1.slug})))
+        assert_that(resp_json, match_equality(
+            has_entries({"slug": collector_type_2.slug})))
+
+    def test_post(self):
+        collector_type = {
+            "slug": "some-collector-type",
+            "name": "some-collector-type",
+            "entry_point": "some.collector.type",
+            "provider_id": self.provider.id
+        }
+
+        resp = self.client.post(
+            '/collector-type',
+            data=to_json(collector_type),
+            HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
+            content_type='application/json')
+
+        assert_that(resp.status_code, equal_to(200))
+
+        resp_json = json.loads(resp.content)
+
+        assert_that(resp_json, has_key('id'))
+        assert_that(resp_json['slug'], equal_to('some-collector-type'))
+        assert_that(resp_json['name'], equal_to('some-collector-type'))
+        assert_that(resp_json['entry_point'], equal_to('some.collector.type'))
+        assert_that(resp_json['provider']['name'], equal_to(
+            self.provider.name))
+
+    def test_post_from_unauthorised_client_fails(self):
+        collector_type = {
+            "slug": "some-collector-type",
+            "name": "some-collector-type",
+            "entry_point": "some.collector.type",
+            "provider": self.provider.id
+        }
+        resp = self.client.post(
+            '/collector-type',
+            data=to_json(collector_type),
+            content_type='application/json')
+
+        assert_that(resp.status_code, equal_to(403))
+
+    def test_post_with_non_existent_provider_fails(self):
+        provider = uuid.UUID('01234a12-1234-1234-5b6c-0de12e3a4f15')
+        collector_type = {
+            "slug": "some-collector-type",
+            "name": "some-collector-type",
+            "entry_point": "some.collector.type",
+            "provider_id": provider
+        }
+        response = self.client.post(
+            '/collector-type',
+            data=to_json(collector_type),
+            HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
+            content_type='application/json')
+
+        assert_that(response.status_code, equal_to(400))
+
+        resp_json = json.loads(response.content)
+        assert_that(resp_json['message'], equal_to(
+            "No provider with id '{}' found".format(provider)))
+
+
+class CollectorViewTestCase(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.provider = ProviderFactory()
+        cls.data_source = DataSourceFactory(provider=cls.provider)
+        cls.collector_type = CollectorTypeFactory(provider=cls.provider)
+        cls.data_set = DataSetFactory()
+
+    @classmethod
+    @disable_backdrop_connection
+    def tearDownClass(cls):
+        cls.provider.delete()
+        cls.data_source.delete()
+        cls.collector_type.delete()
+        cls.data_set.delete()
+        cls.data_set.data_group.delete()
+        cls.data_set.data_type.delete()
+
+    def test_get(self):
+        collector = CollectorFactory()
+        response = self.client.get(
+            '/collector/{}'.format(collector.slug),
+            HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
+            content_type='application/json')
+
+        assert_that(response.status_code, equal_to(200))
+
+        resp_json = json.loads(response.content)
+
+        assert_that(resp_json['id'], equal_to(str(collector.id)))
+        assert_that(resp_json['slug'], equal_to(collector.slug))
+        assert_that(resp_json['name'], equal_to(collector.name))
+        assert_that(resp_json['type']['name'], equal_to(
+            collector.type.name))
+        assert_that(
+            resp_json['data_source']['name'], equal_to(
+                collector.data_source.name))
+        assert_that(resp_json['data_set']['data_type'], equal_to(
+            collector.data_set.data_type.name))
+        assert_that(resp_json['data_set']['data_group'], equal_to(
+            collector.data_set.data_group.name))
+        assert_that(resp_json['query'], equal_to(collector.query))
+        assert_that(resp_json['options'], equal_to(collector.options))
+
+    def test_get_from_unauthorised_client_fails(self):
+        collector = CollectorFactory()
+        resp = self.client.get(
+            '/collector/{}'.format(collector.slug))
+
+        assert_that(resp.status_code, equal_to(403))
+
+    def test_list(self):
+        collector_1 = CollectorFactory()
+        collector_2 = CollectorFactory()
+
+        response = self.client.get(
+            '/collector',
+            HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
+            content_type='application/json')
+
+        assert_that(response.status_code, equal_to(200))
+
+        resp_json = json.loads(response.content)
+
+        assert_that(resp_json, match_equality(
+            has_entries({"slug": collector_1.slug})))
+        assert_that(resp_json, match_equality(
+            has_entries({"slug": collector_2.slug})))
+
+    def test_post(self):
+        collector = {
+            "slug": "some-collector",
+            "type_id": self.collector_type.id,
+            "data_source_id": self.data_source.id,
+            "data_set": {
+                "data_type": self.data_set.data_type.name,
+                "data_group": self.data_set.data_group.name
+            }
+        }
+
+        resp = self.client.post(
+            '/collector',
+            data=to_json(collector),
+            HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
+            content_type='application/json')
+
+        expected_collector_name = "{} {} {}".format(
+            self.collector_type.name,
+            self.data_set.data_group.name,
+            self.data_set.data_type.name
+        )
+
+        assert_that(resp.status_code, equal_to(200))
+
+        resp_json = json.loads(resp.content)
+
+        assert_that(resp_json, has_key('id'))
+        assert_that(resp_json['slug'], equal_to("some-collector"))
+        assert_that(resp_json['name'], equal_to(expected_collector_name))
+        assert_that(resp_json['data_source']['name'],
+                    equal_to(self.data_source.name))
+        assert_that(resp_json['data_set']['data_type'],
+                    equal_to(self.data_set.data_type.name))
+        assert_that(resp_json['data_set']['data_group'],
+                    equal_to(self.data_set.data_group.name))
+
+    def test_post_from_unauthorised_client_fails(self):
+        collector = {
+            "slug": "some-collector",
+            "type_id": self.collector_type.id,
+            "data_source": self.data_source.id,
+            "data_set": {
+                "data_type": self.data_set.data_type.name,
+                "data_group": self.data_set.data_group.name
+            }
+        }
+        resp = self.client.post(
+            '/collector',
+            data=to_json(collector),
+            content_type='application/json')
+
+        assert_that(resp.status_code, equal_to(403))
+
+    def test_post_with_non_existent_data_source_fails(self):
+        data_source = uuid.UUID('01234a12-1234-1234-5b6c-0de12e3a4f15')
+        collector = {
+            "slug": "some-collector",
+            "type_id": self.collector_type.id,
+            "data_source_id": data_source,
+            "data_set": {
+                "data_type": self.data_set.data_type.name,
+                "data_group": self.data_set.data_group.name
+            }
+        }
+        response = self.client.post(
+            '/collector',
+            data=to_json(collector),
+            HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
+            content_type='application/json')
+
+        assert_that(response.status_code, equal_to(400))
+
+        resp_json = json.loads(response.content)
+        assert_that(resp_json['message'], equal_to(
+            "No data source with id '{}' found".format(data_source)))
+
+    def test_post_with_non_existent_collector_type_fails(self):
+        collector_type = uuid.UUID('01234a12-1234-1234-5b6c-0de12e3a4f15')
+        collector = {
+            "slug": "some-collector",
+            "type_id": collector_type,
+            "data_source_id": self.data_source.id,
+            "data_set": {
+                "data_type": self.data_set.data_type.name,
+                "data_group": self.data_set.data_group.name
+            }
+        }
+        response = self.client.post(
+            '/collector',
+            data=to_json(collector),
+            HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
+            content_type='application/json')
+
+        assert_that(response.status_code, equal_to(400))
+
+        resp_json = json.loads(response.content)
+        assert_that(resp_json['message'], equal_to(
+            "No collector type with id '{}' found".format(collector_type)))
+
+    def test_post_with_non_existent_data_set_fails(self):
+        data_set = {
+            "data_type": "some-data-type",
+            "data_group": "some-data-group"
+        }
+        collector = {
+            "slug": "some-collector",
+            "type_id": self.collector_type.id,
+            "data_source_id": self.data_source.id,
+            "data_set": data_set
+        }
+        response = self.client.post(
+            '/collector',
+            data=to_json(collector),
+            HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
+            content_type='application/json')
+
+        assert_that(response.status_code, equal_to(400))
+
+        resp_json = json.loads(response.content)
+        assert_that(resp_json['message'], equal_to(
+            "No data set with data group '{}' and data type '{}' found"
+            "".format(data_set['data_group'], data_set['data_type'])))

--- a/stagecraft/apps/collectors/views.py
+++ b/stagecraft/apps/collectors/views.py
@@ -1,0 +1,343 @@
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import never_cache
+from django.views.decorators.vary import vary_on_headers
+from stagecraft.apps.collectors.models import Provider, DataSource, \
+    CollectorType, Collector
+from stagecraft.apps.datasets.models import DataSet
+from stagecraft.libs.authorization.http import _get_resource_role_permissions
+from stagecraft.libs.views.resource import ResourceView, UUID_RE_STRING
+from stagecraft.libs.views.utils import create_http_error
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel('ERROR')
+
+
+class ProviderView(ResourceView):
+    model = Provider
+
+    schema = {
+        "$schema": "http://json-schema.org/schema#",
+        "type": "object",
+        "properties": {
+            "slug": {
+                "type": "string",
+            },
+            "name": {
+                "type": "string"
+            },
+            "credentials_schema": {
+                "type": "object"
+            }
+        },
+        "required": ["name", "slug"],
+        "additionalProperties": False,
+    }
+
+    id_fields = {
+        'id': UUID_RE_STRING,
+        'slug': '[\w-]+',
+    }
+    list_filters = {
+        "name": "name__iexact"
+    }
+
+    permissions = _get_resource_role_permissions('Provider')
+
+    @method_decorator(never_cache)
+    @method_decorator(vary_on_headers('Authorization'))
+    def get(self, request, **kwargs):
+        return super(ProviderView, self).get(request, **kwargs)
+
+    @method_decorator(never_cache)
+    @method_decorator(vary_on_headers('Authorization'))
+    def post(self, request, **kwargs):
+        return super(ProviderView, self).post(request, **kwargs)
+
+    @method_decorator(never_cache)
+    @method_decorator(vary_on_headers('Authorization'))
+    def put(self, request, **kwargs):
+        return super(ProviderView, self).post(request, **kwargs)
+
+    def update_model(self, model, model_json, request, parent):
+        for (key, value) in model_json.items():
+            setattr(model, key, value)
+
+    @staticmethod
+    def serialize(model):
+        return {
+            'id': str(model.id),
+            'slug': model.slug,
+            'name': model.name,
+            'credentials_schema': model.credentials_schema
+        }
+
+
+class DataSourceView(ResourceView):
+    model = DataSource
+
+    schema = {
+        "$schema": "http://json-schema.org/schema#",
+        "type": "object",
+        "properties": {
+            "slug": {
+                "type": "string"
+            },
+            "name": {
+                "type": "string"
+            },
+            "provider_id": {
+                "type": "string",
+                "format": "uuid"
+            },
+            "credentials": {
+                "type": "object"
+            }
+        },
+        "required": ["name", "slug", "provider_id"],
+        "additionalProperties": False,
+    }
+
+    id_fields = {
+        'id': UUID_RE_STRING,
+        'slug': '[\w-]+',
+    }
+    list_filters = {
+        "name": "name__iexact"
+    }
+
+    permissions = _get_resource_role_permissions('DataSource')
+
+    @method_decorator(never_cache)
+    @method_decorator(vary_on_headers('Authorization'))
+    def get(self, request, **kwargs):
+        return super(DataSourceView, self).get(request, **kwargs)
+
+    @method_decorator(never_cache)
+    @method_decorator(vary_on_headers('Authorization'))
+    def post(self, request, **kwargs):
+        return super(DataSourceView, self).post(request, **kwargs)
+
+    @method_decorator(never_cache)
+    @method_decorator(vary_on_headers('Authorization'))
+    def put(self, request, **kwargs):
+        return super(DataSourceView, self).post(request, **kwargs)
+
+    def update_model(self, model, model_json, request, parent):
+        try:
+            provider = Provider.objects.get(id=model_json['provider_id'])
+            model_json['provider'] = provider
+            for (key, value) in model_json.items():
+                setattr(model, key, value)
+        except Provider.DoesNotExist:
+            message = "No provider with id '{}' found".format(
+                model_json['provider_id'])
+            return create_http_error(400, message, request, logger=logger)
+
+    @staticmethod
+    def serialize(model):
+        return {
+            'id': str(model.id),
+            'slug': model.slug,
+            'name': model.name,
+            'provider': {
+                'id': str(model.provider.id),
+                'slug': model.provider.slug,
+                'name': model.provider.name
+            }
+        }
+
+
+class CollectorTypeView(ResourceView):
+    model = CollectorType
+
+    schema = {
+        "$schema": "http://json-schema.org/schema#",
+        "type": "object",
+        "properties": {
+            "slug": {
+                "type": "string"
+            },
+            "name": {
+                "type": "string"
+            },
+            "provider_id": {
+                "type": "string",
+                "format": "uuid"
+            },
+            "entry_point": {
+                "type": "string"
+            },
+            "query_schema": {
+                "type": "object"
+            },
+            "options_schema": {
+                "type": "object"
+            }
+        },
+        "required": ["name", "slug", "provider_id", "entry_point"],
+        "additionalProperties": False,
+    }
+
+    id_fields = {
+        'id': UUID_RE_STRING,
+        'slug': '[\w-]+',
+    }
+    list_filters = {
+        "name": "name__iexact"
+    }
+
+    permissions = _get_resource_role_permissions('CollectorType')
+
+    @method_decorator(never_cache)
+    @method_decorator(vary_on_headers('Authorization'))
+    def get(self, request, **kwargs):
+        return super(CollectorTypeView, self).get(request, **kwargs)
+
+    @method_decorator(never_cache)
+    @method_decorator(vary_on_headers('Authorization'))
+    def post(self, request, **kwargs):
+        return super(CollectorTypeView, self).post(request, **kwargs)
+
+    @method_decorator(never_cache)
+    @method_decorator(vary_on_headers('Authorization'))
+    def put(self, request, **kwargs):
+        return super(CollectorTypeView, self).post(request, **kwargs)
+
+    def update_model(self, model, model_json, request, parent):
+        try:
+            provider = Provider.objects.get(id=model_json['provider_id'])
+            model_json['provider'] = provider
+            for (key, value) in model_json.items():
+                setattr(model, key, value)
+        except Provider.DoesNotExist:
+            message = "No provider with id '{}' found".format(
+                model_json['provider_id'])
+            return create_http_error(400, message, request, logger=logger)
+
+    @staticmethod
+    def serialize(model):
+        return {
+            'id': str(model.id),
+            'slug': model.slug,
+            'name': model.name,
+            'entry_point': model.entry_point,
+            'query_schema': model.query_schema,
+            'options_schema': model.options_schema,
+            'provider': {
+                'id': str(model.provider.id),
+                'slug': model.provider.slug,
+                'name': model.provider.name
+            }
+        }
+
+
+class CollectorView(ResourceView):
+    model = Collector
+
+    schema = {
+        "$schema": "http://json-schema.org/schema#",
+        "type": "object",
+        "properties": {
+            "slug": {
+                "type": "string"
+            },
+            "type_id": {
+                "type": "string",
+                "format": "uuid"
+            },
+            "data_source_id": {
+                "type": "string",
+                "format": "uuid"
+            },
+            "data_set": {
+                "type": "object"
+            },
+            "query": {
+                "type": "object"
+            },
+            "options": {
+                "type": "object"
+            }
+        },
+        "required": ["slug", "type_id", "data_source_id", "data_set"],
+        "additionalProperties": False,
+    }
+
+    id_fields = {
+        'id': UUID_RE_STRING,
+        'slug': '[\w-]+',
+    }
+    list_filters = {
+        "name": "name__iexact"
+    }
+
+    permissions = _get_resource_role_permissions('Collector')
+
+    @method_decorator(never_cache)
+    @method_decorator(vary_on_headers('Authorization'))
+    def get(self, request, **kwargs):
+        return super(CollectorView, self).get(request, **kwargs)
+
+    @method_decorator(never_cache)
+    @method_decorator(vary_on_headers('Authorization'))
+    def post(self, request, **kwargs):
+        return super(CollectorView, self).post(request, **kwargs)
+
+    @method_decorator(never_cache)
+    @method_decorator(vary_on_headers('Authorization'))
+    def put(self, request, **kwargs):
+        return super(CollectorView, self).post(request, **kwargs)
+
+    def update_model(self, model, model_json, request, parent):
+        try:
+            collector_type = CollectorType.objects.get(
+                id=model_json['type_id'])
+            data_source = DataSource.objects.get(
+                id=model_json['data_source_id'])
+            data_set = DataSet.objects.get(
+                data_group__name=model_json['data_set']['data_group'],
+                data_type__name=model_json['data_set']['data_type'])
+            model_json['type'] = collector_type
+            model_json['data_source'] = data_source
+            model_json['data_set'] = data_set
+
+            for (key, value) in model_json.items():
+                setattr(model, key, value)
+        except CollectorType.DoesNotExist:
+            message = "No collector type with id '{}' found".format(
+                model_json['type_id'])
+            return create_http_error(400, message, request, logger=logger)
+        except DataSource.DoesNotExist:
+            message = "No data source with id '{}' found".format(
+                model_json['data_source_id'])
+            return create_http_error(400, message, request, logger=logger)
+        except DataSet.DoesNotExist:
+            message = "No data set with data group '{}' and data type '{}' " \
+                      "found".format(model_json['data_set']['data_group'],
+                                     model_json['data_set']['data_type'])
+            return create_http_error(400, message, request, logger=logger)
+
+    @staticmethod
+    def serialize(model):
+        return {
+            'id': str(model.id),
+            'slug': model.slug,
+            'name': model.name,
+            'query': model.query,
+            'options': model.options,
+            'type': {
+                'id': str(model.type.id),
+                'slug': model.type.slug,
+                'name': model.type.name
+            },
+            'data_source': {
+                'id': str(model.data_source.id),
+                'slug': model.data_source.slug,
+                'name': model.data_source.name
+            },
+            'data_set': {
+                'data_type': model.data_set.data_type.name,
+                'data_group': model.data_set.data_group.name
+            }
+        }

--- a/stagecraft/apps/dashboards/views/dashboard.py
+++ b/stagecraft/apps/dashboards/views/dashboard.py
@@ -1,21 +1,15 @@
 import logging
 
 from django.conf import settings
-from django.http import (HttpResponse,
-                         HttpResponseNotFound)
-from django.utils.decorators import method_decorator
-from django.views.decorators.cache import never_cache
-from django.views.decorators.vary import vary_on_headers
+from django.http import (HttpResponse)
 
 from stagecraft.apps.dashboards.models.dashboard import Dashboard
 from stagecraft.apps.organisation.models import Node
 from stagecraft.libs.validation.validation import is_uuid
 from stagecraft.libs.views.resource import ResourceView, UUID_RE_STRING
-from stagecraft.libs.views.utils import to_json, create_error, \
-    create_http_error
+from stagecraft.libs.views.utils import to_json, create_http_error
 from .module import add_module_to_dashboard, ModuleView
 import time
-from stagecraft.libs.authorization.http import _get_resource_role_permissions
 
 logger = logging.getLogger(__name__)
 
@@ -174,24 +168,6 @@ class DashboardView(ResourceView):
         'id': 'id__iexact',
         'slug': 'slug_iexact'
     }
-
-    permissions = _get_resource_role_permissions('Dashboard')
-
-    @method_decorator(never_cache)
-    def get(self, request, **kwargs):
-        return super(DashboardView, self).get(request, **kwargs)
-
-    @method_decorator(vary_on_headers('Authorization'))
-    def post(self, request, **kwargs):
-        return super(DashboardView, self).post(request, **kwargs)
-
-    @method_decorator(vary_on_headers('Authorization'))
-    def put(self, request, **kwargs):
-        return super(DashboardView, self).put(request, **kwargs)
-
-    @method_decorator(vary_on_headers('Authorization'))
-    def delete(self, request, **kwargs):
-        return super(DashboardView, self).delete(request, **kwargs)
 
     def update_model(self, model, model_json, request, parent):
 

--- a/stagecraft/apps/dashboards/views/module.py
+++ b/stagecraft/apps/dashboards/views/module.py
@@ -13,8 +13,7 @@ from stagecraft.apps.datasets.models import DataSet
 from stagecraft.libs.validation.validation import is_uuid
 
 from ..models import Dashboard, Module, ModuleType
-from stagecraft.libs.views.utils import create_http_error
-from stagecraft.libs.authorization.http import _get_resource_role_permissions
+from stagecraft.libs.views.utils import create_http_error, add_items_to_model
 
 
 def json_response(obj):
@@ -173,8 +172,6 @@ class ModuleView(ResourceView):
         "additionalProperties": False,
     }
 
-    permissions = _get_resource_role_permissions('Module')
-
     def list(self, request, **kwargs):
         query_set = super(ModuleView, self).list(request, **kwargs)
 
@@ -184,12 +181,10 @@ class ModuleView(ResourceView):
         return query_set
 
     @csrf_exempt
-    @method_decorator(never_cache)
     def get(self, request, **kwargs):
         return super(ModuleView, self).get(request, **kwargs)
 
     @csrf_exempt
-    @method_decorator(never_cache)
     def put(self, request, **kwargs):
         return create_http_error(
             405,
@@ -287,15 +282,8 @@ class ModuleTypeView(ResourceView):
         'name': 'name__iexact'
     }
 
-    permissions = _get_resource_role_permissions('ModuleType')
-
-    @method_decorator(never_cache)
-    def get(self, request, **kwargs):
-        return super(ModuleTypeView, self).get(request, **kwargs)
-
     def update_model(self, model, model_json, request, parent):
-        for (key, value) in model_json.items():
-            setattr(model, key, value)
+        add_items_to_model(model, model_json)
 
     @staticmethod
     def serialize(model):

--- a/stagecraft/apps/datasets/views/data_group.py
+++ b/stagecraft/apps/datasets/views/data_group.py
@@ -1,10 +1,6 @@
 from stagecraft.libs.views.resource import ResourceView
 from stagecraft.apps.datasets.models import DataGroup
-from django.utils.decorators import method_decorator
-from django.views.decorators.cache import never_cache
-from django.views.decorators.vary import vary_on_headers
-from stagecraft.libs.authorization.http import (
-    permission_required, _get_resource_role_permissions)
+from stagecraft.libs.views.utils import add_items_to_model
 
 
 class DataGroupView(ResourceView):
@@ -16,23 +12,8 @@ class DataGroupView(ResourceView):
         "name": "name"
     }
 
-    permissions = _get_resource_role_permissions('DataGroup')
-
-    @method_decorator(never_cache)
-    @method_decorator(vary_on_headers('Authorization'))
-    def get(self, request, **kwargs):
-        return super(DataGroupView, self).get(
-            request,
-            **kwargs)
-
-    @method_decorator(never_cache)
-    @method_decorator(vary_on_headers('Authorization'))
-    def post(self, request, **kwargs):
-        return super(DataGroupView, self).post(request, **kwargs)
-
     def update_model(self, model, model_json, request, parent):
-        for (key, value) in model_json.items():
-            setattr(model, key, value)
+        add_items_to_model(model, model_json)
 
     @staticmethod
     def serialize(model):

--- a/stagecraft/apps/organisation/views.py
+++ b/stagecraft/apps/organisation/views.py
@@ -5,7 +5,6 @@ from stagecraft.libs.validation.validation import is_uuid
 from stagecraft.libs.views.resource import ResourceView
 from .models import Node, NodeType
 from stagecraft.libs.views.utils import create_http_error
-from stagecraft.libs.authorization.http import _get_resource_role_permissions
 
 
 class NodeTypeView(ResourceView):
@@ -25,12 +24,6 @@ class NodeTypeView(ResourceView):
     list_filters = {
         'name': 'name__iexact',
     }
-
-    permissions = _get_resource_role_permissions('NodeType')
-
-    @method_decorator(never_cache)
-    def get(self, request, **kwargs):
-        return super(NodeTypeView, self).get(request, **kwargs)
 
     def update_model(self, model, model_json, request, parent):
         model.name = model_json['name']
@@ -76,18 +69,12 @@ class NodeView(ResourceView):
         'type': 'typeOf__name',
     }
 
-    permissions = _get_resource_role_permissions('Node')
-
     def list(self, request, **kwargs):
         if 'parent' in kwargs:
             include_self = request.GET.get('self', 'false') == 'true'
             return kwargs['parent'].get_ancestors(include_self=include_self)
         else:
             return super(NodeView, self).list(request, **kwargs)
-
-    @method_decorator(never_cache)
-    def get(self, request, **kwargs):
-        return super(NodeView, self).get(request, **kwargs)
 
     def update_model(self, model, model_json, request, parent):
         try:

--- a/stagecraft/apps/transforms/views.py
+++ b/stagecraft/apps/transforms/views.py
@@ -1,15 +1,3 @@
-import json
-
-from django.http import HttpResponse
-from django.utils.decorators import method_decorator
-from django.views.decorators.csrf import csrf_exempt
-from django.views.decorators.http import require_GET
-from django.views.decorators.cache import never_cache
-
-from stagecraft.libs.authorization.http import (
-    permission_required, _get_resource_role_permissions)
-from stagecraft.libs.validation.validation import is_uuid
-
 from stagecraft.apps.datasets.models import DataGroup, DataType
 from .models import Transform, TransformType
 
@@ -58,12 +46,6 @@ class TransformTypeView(ResourceView):
         "required": ["name", "function", "schema"],
         "additionalProperties": False,
     }
-
-    permissions = _get_resource_role_permissions('TransformType')
-
-    @method_decorator(never_cache)
-    def get(self, request, **kwargs):
-        return super(TransformTypeView, self).get(request, **kwargs)
 
     def update_model(self, model, model_json, request, parent):
         model.name = model_json['name']
@@ -134,12 +116,6 @@ class TransformView(ResourceView):
         ],
         "additionalProperties": False,
     }
-
-    permissions = _get_resource_role_permissions('Transform')
-
-    @method_decorator(never_cache)
-    def get(self, request, **kwargs):
-        return super(TransformView, self).get(request, **kwargs)
 
     def update_model(self, model, model_json, request, parent):
         try:

--- a/stagecraft/apps/users/views.py
+++ b/stagecraft/apps/users/views.py
@@ -1,13 +1,6 @@
-from collections import OrderedDict
 import logging
 
-from django.utils.decorators import method_decorator
-from django.views.decorators.cache import never_cache
-from django.views.decorators.vary import vary_on_headers
-
 from stagecraft.apps.users.models import User
-from stagecraft.libs.authorization.http import (
-    permission_required, _get_resource_role_permissions)
 from stagecraft.libs.views.resource import ResourceView
 
 logger = logging.getLogger(__name__)
@@ -36,23 +29,6 @@ class UserView(ResourceView):
     list_filters = {
         'email': 'email__iexact',
     }
-
-    permissions = _get_resource_role_permissions('User')
-
-    @never_cache
-    @vary_on_headers('Authorization')
-    def get(self, request, *args, **kwargs):
-        return super(UserView, self).get(request, **kwargs)
-
-    @never_cache
-    @vary_on_headers('Authorization')
-    def post(self, request, **kwargs):
-        return super(UserView, self).post(request, **kwargs)
-
-    @never_cache
-    @vary_on_headers('Authorization')
-    def put(self, request, **kwargs):
-        return super(UserView, self).put(request, **kwargs)
 
     def update_model(self, model, model_json, request):
         model.email = model_json['email']

--- a/stagecraft/libs/views/tests/test_resource.py
+++ b/stagecraft/libs/views/tests/test_resource.py
@@ -73,10 +73,6 @@ class TestResourceView(ResourceView):
 
     was_saved = False
 
-    permissions = {
-        'get': set(['anon']), 'post': set(['anon']), 'put': set(['anon']),
-        'delete': set(['anon'])}
-
     def update_relationships(self, model, model_json, request, parent):
         self.was_saved = model.pk is not None
 
@@ -183,6 +179,8 @@ class ResourceViewTestCase(TestCase):
         request = HttpRequest()
         request.method = action
         request.META['CONTENT_TYPE'] = content_type
+        request.META['HTTP_AUTHORIZATION'] = \
+            'Bearer development-oauth-access-token'
         request._body = body
 
         if action == 'POST':
@@ -421,6 +419,8 @@ class ResourceViewTestCase(TestCase):
         request = HttpRequest()
         request.method = 'POST'
         request.META['CONTENT_TYPE'] = 'application/json'
+        request.META['HTTP_AUTHORIZATION'] = \
+            'Bearer development-oauth-access-token'
         request._body = json.dumps({
             'type_id': str(node_type.id),
             'name': 'foo',

--- a/stagecraft/libs/views/utils.py
+++ b/stagecraft/libs/views/utils.py
@@ -72,3 +72,8 @@ def create_http_error(status, message, request, code='', title='',
         logger.error(error)
 
     return HttpResponse(to_json(error), status=status)
+
+
+def add_items_to_model(model, model_json):
+    for (key, value) in model_json.items():
+        setattr(model, key, value)

--- a/stagecraft/settings/common.py
+++ b/stagecraft/settings/common.py
@@ -124,6 +124,16 @@ DOGSLOW_LOG_LEVEL = 'INFO'
 
 ROLES = [
     {
+        "role": "collector",
+        "permissions": {
+            "DataSet": ["get"],
+            "Provider": ["get", "post", "put", "delete"],
+            "DataSource": ["get", "post", "put", "delete"],
+            "CollectorType": ["get", "post", "put", "delete"],
+            "Collector": ["get", "post", "put", "delete"]
+        }
+    },
+    {
         "role": "dashboard",
         "permissions": {
             "Dashboard": ["get", "post", "put", "delete"],

--- a/stagecraft/settings/common.py
+++ b/stagecraft/settings/common.py
@@ -158,6 +158,10 @@ ROLES = [
             "Transform": ["get", "post", "put", "delete"],
             "TransformType": ["get", "post", "put", "delete"],
             "User": ["get", "post", "put", "delete"],
+            "Provider": ["get", "post", "put", "delete"],
+            "DataSource": ["get", "post", "put", "delete"],
+            "CollectorType": ["get", "post", "put", "delete"],
+            "Collector": ["get", "post", "put", "delete"],
         },
     },
     {

--- a/stagecraft/urls.py
+++ b/stagecraft/urls.py
@@ -4,6 +4,7 @@ from django.views.generic.base import RedirectView
 
 import stagecraft.apps.organisation.views as organisation_views
 import stagecraft.apps.transforms.views as transforms_views
+import stagecraft.apps.collectors.views as collectors_views
 
 from stagecraft.apps.datasets.views import auth as auth_views
 from stagecraft.apps.datasets.views import data_set as datasets_views
@@ -75,5 +76,9 @@ urlpatterns = patterns(
     resource_url('module-type', module_views.ModuleTypeView),
     resource_url('module', module_views.ModuleView),
     resource_url('dashboard', dashboard_views.DashboardView),
-    resource_url('users', user_views.UserView)
+    resource_url('users', user_views.UserView),
+    resource_url('provider', collectors_views.ProviderView),
+    resource_url('data-source', collectors_views.DataSourceView),
+    resource_url('collector-type', collectors_views.CollectorTypeView),
+    resource_url('collector', collectors_views.CollectorView)
 )


### PR DESCRIPTION
The views added:
* Provider View
* DataSource View
* CollectorType View
* Collector View

Each view inherits from Resource View and has a schema.

Move common function calls to base ResourceView class
* Moved call to decorator that prohibits caching of results to Resource View.
* Move the call to the add an Authorization header to Resource View.
* Move finding permissions by resource (model) name to ResourceView

The changes will apply to all operations of all views that inherit from Resource View.

https://www.pivotaltracker.com/story/show/99687256