### PR TITLE
Add celery job queue to Stagecraft

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,4 @@
 web: ./venv/bin/gunicorn stagecraft.wsgi:application --bind 127.0.0.1:3103 --workers 4
+worker: ./venv/bin/python manage.py --settings=stagecraft.settings.production celery worker -E -l debug
+beat: ./venv/bin/python manage.py --settings=stagecraft.settings.production celery beat -l debug
+celerycam: ./venv/bin/python manage.py --settings=stagecraft.settings.production celerycam

--- a/requirements/_common.txt
+++ b/requirements/_common.txt
@@ -1,6 +1,7 @@
 # requirements/common.txt: Used on *all* environments.
 
 django==1.8.2
+django-celery==3.1.16
 django-dbarray==0.2
 -e git+https://github.com/incuna/django-field-cryptography.git@v1.0.1#egg=django-field-cryptography
 django-mptt==0.6.1

--- a/stagecraft/apps/collectors/tasks.py
+++ b/stagecraft/apps/collectors/tasks.py
@@ -1,0 +1,9 @@
+from celery import shared_task
+from celery.utils.log import get_task_logger
+
+logger = get_task_logger(__name__)
+
+
+@shared_task
+def log(message):
+    logger.info(message)

--- a/stagecraft/settings/common.py
+++ b/stagecraft/settings/common.py
@@ -22,6 +22,10 @@ BASE_DIR = abspath(pjoin(dirname(__file__), '..', '..'))
 sys.path.append(pjoin(BASE_DIR, 'apps'))
 sys.path.append(pjoin(BASE_DIR, 'libs'))
 
+import djcelery
+
+djcelery.setup_loader()
+
 # Defined here for safety, they should also be defined in each environment.
 DEBUG = False
 TEMPLATE_DEBUG = False
@@ -63,6 +67,7 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
 
+    'djcelery',
     'reversion',
 
     'stagecraft.apps.collectors',
@@ -121,6 +126,15 @@ DOGSLOW_LOG_TO_FILE = False
 DOGSLOW_TIMER = 1
 DOGSLOW_LOGGER = 'stagecraft.apps'
 DOGSLOW_LOG_LEVEL = 'INFO'
+
+#: Only add pickle to this list if your broker is secured
+#: from unwanted access (see userguide/security.html)
+CELERY_ACCEPT_CONTENT = ['json']
+CELERY_TASK_SERIALIZER = 'json'
+CELERY_RESULT_SERIALIZER = 'json'
+
+CELERY_RESULT_BACKEND = 'djcelery.backends.database.DatabaseBackend'
+CELERYBEAT_SCHEDULER = 'djcelery.schedulers.DatabaseScheduler'
 
 ROLES = [
     {

--- a/stagecraft/settings/development.py
+++ b/stagecraft/settings/development.py
@@ -203,3 +203,5 @@ LOGGING = {
 }
 
 TRANSFORMED_DATA_SET_TOKEN = 'this-token-is-irrelevant'
+
+BROKER_URL = 'amqp://stagecraft:stagecraft@localhost//stagecraft'


### PR DESCRIPTION
We use django-celery because it provides us with a set of models for
controlling periodic jobs and the scheduler for celerybeat to execute
them.

This adds 3 new process types to the Procfile:
   - `worker` the process that will consume the jobs to be executed and
     run them. The `-E` tells the process to emit events that will be
     consumed by the celerycam process to store state of jobs
   - `beat` reads from the database and triggers scheduled periodic jobs
   - `celerycam` reads the state of running jobs periodically and stores
     this information in the database