### PR TITLE
Return CollectorType details in Collector View

### DIFF
--- a/requirements/_common.txt
+++ b/requirements/_common.txt
@@ -16,7 +16,7 @@ cryptography==0.9.3
 psycopg2==2.5.4
 
 # For performing data operations that require speaking to backdrop
-performanceplatform-client==0.2.4
+performanceplatform-client==0.11.1
 
 # For writing stats out about our code
 statsd==3.0.1

--- a/stagecraft/apps/collectors/tests/test_views.py
+++ b/stagecraft/apps/collectors/tests/test_views.py
@@ -415,6 +415,10 @@ class CollectorViewTestCase(TestCase):
         assert_that(resp_json['name'], equal_to(collector.name))
         assert_that(resp_json['type']['name'], equal_to(
             collector.type.name))
+        assert_that(resp_json['type']['slug'], equal_to(
+            collector.type.slug))
+        assert_that(resp_json['entry_point'], equal_to(
+            collector.type.entry_point))
         assert_that(
             resp_json['data_source']['name'], equal_to(
                 collector.data_source.name))
@@ -422,8 +426,13 @@ class CollectorViewTestCase(TestCase):
             collector.data_set.data_type.name))
         assert_that(resp_json['data_set']['data_group'], equal_to(
             collector.data_set.data_group.name))
+        assert_that(resp_json['data_set'], has_key('bearer_token'))
         assert_that(resp_json['query'], equal_to(collector.query))
         assert_that(resp_json['options'], equal_to(collector.options))
+        assert_that(resp_json['provider']['slug'], equal_to(
+            collector.type.provider.slug))
+        assert_that(resp_json['provider']['name'], equal_to(
+            collector.type.provider.name))
         assert_that(resp_json, not(has_key('owners')))
 
     def test_get_from_unauthorised_client_fails(self):

--- a/stagecraft/apps/collectors/views.py
+++ b/stagecraft/apps/collectors/views.py
@@ -248,6 +248,7 @@ class CollectorView(ResourceView):
             'name': model.name,
             'query': model.query,
             'options': model.options,
+            'entry_point': model.type.entry_point,
             'type': {
                 'id': str(model.type.id),
                 'slug': model.type.slug,
@@ -260,6 +261,12 @@ class CollectorView(ResourceView):
             },
             'data_set': {
                 'data_type': model.data_set.data_type.name,
-                'data_group': model.data_set.data_group.name
+                'data_group': model.data_set.data_group.name,
+                'bearer_token': model.data_set.bearer_token
+            },
+            'provider': {
+                'id': str(model.type.provider.id),
+                'slug': model.type.provider.slug,
+                'name': model.type.provider.name
             }
         }


### PR DESCRIPTION
Some of the details required to run a collector are stored in CollectorType.

Too avoid having to make multiple HTTP calls, these details are being
returned by the CollectorView.

CollectorTypeView remains unchanged.