### PR TITLE
Check that collector models can be listed.

### DIFF
--- a/stagecraft/apps/collectors/models.py
+++ b/stagecraft/apps/collectors/models.py
@@ -8,6 +8,7 @@ from django_field_cryptography import fields as encrypted_fields
 from jsonfield import JSONField
 from stagecraft.apps.datasets.models import DataSet
 from stagecraft.apps.users.models import User
+from django.db.models.query import QuerySet
 
 
 class Provider(models.Model):
@@ -36,7 +37,18 @@ class Provider(models.Model):
         return "{}".format(self.name)
 
 
+class DataSourceManager(models.Manager):
+
+    def get_query_set(self):
+        return QuerySet(self.model, using=self._db)
+
+    def for_user(self, user):
+        return self.get_query_set().filter(owners=user)
+
+
 class DataSource(models.Model):
+    objects = DataSourceManager()
+
     id = models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True)
     slug = models.SlugField(max_length=100, unique=True)
     name = models.CharField(max_length=256, unique=True)
@@ -118,7 +130,18 @@ class CollectorType(models.Model):
         return "{}: {}".format(self.provider.name, self.name)
 
 
+class CollectorManager(models.Manager):
+
+    def get_query_set(self):
+        return QuerySet(self.model, using=self._db)
+
+    def for_user(self, user):
+        return self.get_query_set().filter(owners=user)
+
+
 class Collector(models.Model):
+    objects = CollectorManager()
+
     id = models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True)
     slug = models.SlugField(max_length=100, unique=True)
 

--- a/stagecraft/apps/collectors/tests/test_views.py
+++ b/stagecraft/apps/collectors/tests/test_views.py
@@ -47,6 +47,37 @@ class ProviderViewTestCase(TestCase):
 
         assert_that(resp.status_code, equal_to(403))
 
+    def test_list(self):
+        provider_1 = ProviderFactory()
+        provider_2 = ProviderFactory()
+
+        response = self.client.get(
+            '/provider',
+            HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
+            content_type='application/json')
+
+        assert_that(response.status_code, equal_to(200))
+
+        resp_json = json.loads(response.content)
+
+        assert_that(resp_json, match_equality(
+            has_entries({"slug": provider_1.slug})))
+        assert_that(resp_json, match_equality(
+            has_entries({"slug": provider_2.slug})))
+
+    # The list route requires for_user if you're not an admin and the model
+    # has an owner attribute. This test implicitly tests whether the for_user
+    # method and the accompanying model Manager class is required.
+    @with_govuk_signon(permissions=['collector'])
+    def test_can_list_providers_with_collector_permission(self):
+        provider = ProviderFactory()
+
+        response = self.client.get(
+            '/provider',
+            HTTP_AUTHORIZATION='Bearer correct-token')
+
+        assert_that(response.status_code, equal_to(200))
+
     def test_post(self):
         provider = {
             "name": "some-provider",
@@ -146,6 +177,37 @@ class DataSourceViewTestCase(TestCase):
             '/data-source/{}'.format(data_source.name))
 
         assert_that(resp.status_code, equal_to(403))
+
+    def test_list(self):
+        data_source_1 = DataSourceFactory()
+        data_source_2 = DataSourceFactory()
+
+        response = self.client.get(
+            '/data-source',
+            HTTP_AUTHORIZATION='Bearer development-oauth-access-token',
+            content_type='application/json')
+
+        assert_that(response.status_code, equal_to(200))
+
+        resp_json = json.loads(response.content)
+
+        assert_that(resp_json, match_equality(
+            has_entries({"slug": data_source_1.slug})))
+        assert_that(resp_json, match_equality(
+            has_entries({"slug": data_source_2.slug})))
+
+    # The list route requires for_user if you're not an admin and the model
+    # has an owner attribute. This test implicitly tests whether the for_user
+    # method and the accompanying model Manager class is required.
+    @with_govuk_signon(permissions=['collector'])
+    def test_can_list_data_sources_with_collector_permission(self):
+        data_source = DataSourceFactory()
+
+        response = self.client.get(
+            '/data-source',
+            HTTP_AUTHORIZATION='Bearer correct-token')
+
+        assert_that(response.status_code, equal_to(200))
 
     def test_post(self):
         data_source = {
@@ -299,6 +361,19 @@ class CollectorTypeViewTestCase(TestCase):
             has_entries({"slug": collector_type_1.slug})))
         assert_that(resp_json, match_equality(
             has_entries({"slug": collector_type_2.slug})))
+
+    # The list route requires for_user if you're not an admin and the model
+    # has an owner attribute. This test implicitly tests whether the for_user
+    # method and the accompanying model Manager class is required.
+    @with_govuk_signon(permissions=['collector'])
+    def test_can_list_collector_types_with_collector_permission(self):
+        collector_type = CollectorTypeFactory()
+
+        response = self.client.get(
+            '/collector-type',
+            HTTP_AUTHORIZATION='Bearer correct-token')
+
+        assert_that(response.status_code, equal_to(200))
 
     def test_post(self):
         collector_type = {
@@ -459,6 +534,19 @@ class CollectorViewTestCase(TestCase):
             has_entries({"slug": collector_1.slug})))
         assert_that(resp_json, match_equality(
             has_entries({"slug": collector_2.slug})))
+
+    # The list route requires for_user if you're not an admin and the model
+    # has an owner attribute. This test implicitly tests whether the for_user
+    # method and the accompanying model Manager class is required.
+    @with_govuk_signon(permissions=['collector'])
+    def test_can_list_collectors_with_collector_permission(self):
+        collector = CollectorFactory()
+
+        response = self.client.get(
+            '/collector',
+            HTTP_AUTHORIZATION='Bearer correct-token')
+
+        assert_that(response.status_code, equal_to(200))
 
     def test_post(self):
         collector = {


### PR DESCRIPTION
Models that have an owners attribute need to have a for_user method
defined in the model manager to be able to call list on the models.

Added a Manager for the Collector and DataSource models.

Added tests to check that all of the associated collector models can
be listed if the user is an admin or has the collector permission.