### PR TITLE
Delete oauth users between runs

### DIFF
--- a/stagecraft/apps/datasets/tests/views/test_auth.py
+++ b/stagecraft/apps/datasets/tests/views/test_auth.py
@@ -60,7 +60,7 @@ class OAuthInvalidateTestCase(TestCase):
                 HTTP_AUTHORIZATION='Bearer correct-token')
             assert_that(resp, is_forbidden())
             assert_that(
-                OAuthUser.objects.get_by_access_token('the-token'),
+                OAuthUser.objects.get_by_access_token('correct-token'),
                 is_not(None))
 
     def test_invalidate_returns_200_if_user_is_not_found(self):

--- a/stagecraft/libs/authorization/tests/test_http.py
+++ b/stagecraft/libs/authorization/tests/test_http.py
@@ -17,6 +17,12 @@ from stagecraft.libs.authorization.http import (
 
 
 def govuk_signon_mock(**kwargs):
+    # So that this behaves as expected, when we use
+    # it be sure to clean out any existing users.
+    # This will prevent loading them from the database
+    # instead of using the signon mock.
+    OAuthUser.objects.all().delete()
+
     @urlmatch(netloc=r'.*signon.*')
     def func(url, request):
         if request.headers['Authorization'] == 'Bearer correct-token':
@@ -148,7 +154,8 @@ class CheckPermissionTestCase(TestCase):
 
         assert_that(has_permission, equal_to(False))
 
-    def test_user_with_returns_object_and_true_when_permissions_is_list(self):
+    def test_check_permission_returns_object_and_true_when_permissions_list(
+            self):
         settings.USE_DEVELOPMENT_USERS = False
 
         OAuthUser.objects.create(access_token='correct-token',


### PR DESCRIPTION
This will make mocking behave as expected.

There are a couple of cases where we request more than once in a test.
In these cases it is appropriate to store in the db in between requests

also rename duplicate test