### PR TITLE
Add option to empty-data-set to GA collector schema

### DIFF
--- a/stagecraft/apps/collectors/schemas/collector-type/ga-contrib-content-table/options.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/ga-contrib-content-table/options.json
@@ -15,6 +15,12 @@
                     "type": "string"
                 }
             }
+        },
+        "chunk-size": {
+            "type": "number"
+        },
+        "empty-data-set": {
+            "type": "boolean"
         }
     },
     "title": "Google Analytics Content Collector Options",

--- a/stagecraft/apps/collectors/schemas/collector-type/ga/options.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/ga/options.json
@@ -154,6 +154,9 @@
         },
         "chunk-size": {
             "type": "number"
+        },
+        "empty-data-set": {
+            "type": "boolean"
         }
     },
     "title": "Google Analytics Collector Options",

--- a/stagecraft/apps/collectors/schemas/collector-type/piwik-core/options.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/piwik-core/options.json
@@ -43,6 +43,12 @@
                 "items": {
                     "type": "string"
                 }
+            },
+            "chunk-size": {
+                "type": "number"
+            },
+            "empty-data-set": {
+                "type": "boolean"
             }
         },
         "title": "Piwik Core Collector Options",

--- a/stagecraft/apps/collectors/schemas/collector-type/piwik-realtime/options.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/piwik-realtime/options.json
@@ -1,6 +1,13 @@
 {
     "$schema": "http://json-schema.org/schema#",
-        "properties": {},
+        "properties": {
+            "chunk-size": {
+                "type": "number"
+            },
+            "empty-data-set": {
+                "type": "boolean"
+            }
+        },
         "title": "Piwik Realtime Collector Options",
         "type": "object",
         "additionalProperties": false

--- a/stagecraft/apps/collectors/schemas/collector-type/webtrends-keymetrics/options.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/webtrends-keymetrics/options.json
@@ -15,6 +15,12 @@
             },
             "row_type_name": {
                 "type": "string"
+            },
+            "chunk-size": {
+                "type": "number"
+            },
+            "empty-data-set": {
+                "type": "boolean"
             }
         },
         "title": "Webtrends Keymetrics Collector Options",

--- a/stagecraft/apps/collectors/schemas/collector-type/webtrends-reports/options.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/webtrends-reports/options.json
@@ -55,6 +55,12 @@
                 "items": {
                     "type": "string"
                 }
+            },
+            "chunk-size": {
+                "type": "number"
+            },
+            "empty-data-set": {
+                "type": "boolean"
             }
         },
         "title": "Webtrends Reports Collector Options",


### PR DESCRIPTION
Allow a parameter to be added to options in the collector conifg
that instructs collectors to purge the contents of dataset everytime
it collects more data.

See: https://github.com/alphagov/performanceplatform-collector/pull/132

Pivotal: https://www.pivotaltracker.com/story/show/100818900