### PR TITLE
Add missing elements to schemas

### DIFF
--- a/stagecraft/apps/collectors/schemas/collector-type/ga-trending/options.json
+++ b/stagecraft/apps/collectors/schemas/collector-type/ga-trending/options.json
@@ -1,6 +1,13 @@
 {
     "$schema": "http://json-schema.org/schema#",
-        "properties": {},
+        "properties": {
+            "idMapping": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
         "title": "Google Analytics Trending Collector Options",
         "type": "object",
         "additionalProperties": false


### PR DESCRIPTION
When we ran the migration scripts to import the collector config into
stagecraft we realised some fields had been missed in the schemas.