### PR TITLE
Use environment variable rather than --settings

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web: ./venv/bin/gunicorn stagecraft.wsgi:application --bind 127.0.0.1:3103 --workers 4
-worker: ./venv/bin/python manage.py --settings=stagecraft.settings.production celery worker -E -l debug
-beat: ./venv/bin/python manage.py --settings=stagecraft.settings.production celery beat -l debug
-celerycam: ./venv/bin/python manage.py --settings=stagecraft.settings.production celerycam
+worker: DJANGO_SETTINGS_MODULE=stagecraft.settings.production./venv/bin/python manage.py celery worker -E -l debug
+beat: DJANGO_SETTINGS_MODULE=stagecraft.settings.production ./venv/bin/python manage.py celery beat -l debug
+celerycam: DJANGO_SETTINGS_MODULE=stagecraft.settings.production ./venv/bin/python manage.py celerycam


### PR DESCRIPTION
Although manage.py seemed to indicate that it would load settings based
of the --settings flag, this doesn't seem to work. This switches the
flag for an environment variable that does work.