### PR TITLE
exec doesn't support inline environment variables

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web: ./venv/bin/gunicorn stagecraft.wsgi:application --bind 127.0.0.1:3103 --workers 4
-worker: DJANGO_SETTINGS_MODULE=stagecraft.settings.production ./venv/bin/python manage.py celery worker -E -l debug
-beat: DJANGO_SETTINGS_MODULE=stagecraft.settings.production ./venv/bin/python manage.py celery beat -l debug
-celerycam: DJANGO_SETTINGS_MODULE=stagecraft.settings.production ./venv/bin/python manage.py celerycam
+worker: ./venv/bin/python manage.py celery --settings=stagecraft.settings.production celery worker -E -l debug
+beat: ./venv/bin/python manage.py celery --settings=stagecraft.settings.production -l debug
+celerycam: ./venv/bin/python manage.py celerycam --settings=stagecraft.settings.production


### PR DESCRIPTION
It turned out that the problem with --settings was that it needs to come
after the command that manage.py will execute, not before. I've tested
this in the dev vm and it seems to work.