### PR TITLE
Celery doesn't support the --settings

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web: ./venv/bin/gunicorn stagecraft.wsgi:application --bind 127.0.0.1:3103 --workers 4
-worker: ./venv/bin/python manage.py celery --settings=stagecraft.settings.production celery worker -E -l debug
-beat: ./venv/bin/python manage.py celery --settings=stagecraft.settings.production -l debug
+worker: ./venv/bin/python manage.py celeryd --settings=stagecraft.settings.production -E -l debug
+beat: ./venv/bin/python manage.py celerybeat --settings=stagecraft.settings.production -l debug
 celerycam: ./venv/bin/python manage.py celerycam --settings=stagecraft.settings.production


### PR DESCRIPTION
It mistakes this for the command you are trying to run and if you switch
to `celery beat` with the --settings after it will complain that
--settings is not an expected option. Luckily they have a couple of
other commands that alais to the two part commands that do work.