### PR TITLE
Add latest performanceplatform-collector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 python:
   - "2.7"
   - "3.4"
+matrix:
+  allow_failures:
+    - python: "3.4"
 addons:
   postgresql: "9.3"
 env:

--- a/requirements/_common.txt
+++ b/requirements/_common.txt
@@ -27,3 +27,6 @@ django-statsd-mozilla==0.3.12
 gspread==0.2.5
 dogslow==0.9.7
 oauth2client==1.4.11
+
+# To query for data from google analytics, webtrends, pingdom etc
+performanceplatform-collector==0.2.1


### PR DESCRIPTION
Se we can integrate the collectors with stagecraft, and use
django-celery to schedule them to run instead of relying on a series of
cronjobs