### PR TITLE
Use write url instead of generic backdrop url

### DIFF
--- a/stagecraft/libs/backdrop_client/backdrop_client.py
+++ b/stagecraft/libs/backdrop_client/backdrop_client.py
@@ -107,8 +107,8 @@ def delete_data_set(name):
     Connect to Backdrop and delete a collection called ``name``.
     """
 
-    endpoint_url = '{url}/data-sets/{name}'.format(url=settings.BACKDROP_URL,
-                                                   name=name)
+    endpoint_url = '{url}/data-sets/{name}'.format(
+        url=settings.BACKDROP_WRITE_URL, name=name)
 
     backdrop_request = lambda: requests.delete(
         endpoint_url,


### PR DESCRIPTION
BACKDROP_URL has been deprecated in favour of specifying the read or
write url directly so that we stay within gov.uk infrastructure and do
not route internal requests via the internet. This needs updating for
the delete endpoint.