### PR TITLE
Run collectors periodically using Celery

### DIFF
--- a/stagecraft/apps/collectors/models.py
+++ b/stagecraft/apps/collectors/models.py
@@ -145,7 +145,7 @@ class Collector(models.Model):
     id = models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True)
     slug = models.SlugField(max_length=100, unique=True)
 
-    type = models.ForeignKey(CollectorType)
+    type = models.ForeignKey(CollectorType, related_name='collectors')
     data_source = models.ForeignKey(DataSource)
     data_set = models.ForeignKey(DataSet)
 

--- a/stagecraft/settings/common.py
+++ b/stagecraft/settings/common.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/1.6/ref/settings/
 import os
 import sys
 from os.path import abspath, dirname, join as pjoin
+from datetime import timedelta
 
 try:
     from urllib.parse import urlparse  # Python 3
@@ -23,6 +24,7 @@ sys.path.append(pjoin(BASE_DIR, 'apps'))
 sys.path.append(pjoin(BASE_DIR, 'libs'))
 
 import djcelery
+from celery.schedules import crontab
 
 djcelery.setup_loader()
 
@@ -135,6 +137,27 @@ CELERY_RESULT_SERIALIZER = 'json'
 
 CELERY_RESULT_BACKEND = 'djcelery.backends.database.DatabaseBackend'
 CELERYBEAT_SCHEDULER = 'djcelery.schedulers.DatabaseScheduler'
+CELERYBEAT_SCHEDULE = {
+    'realtime': {
+        'task': 'stagecraft.apps.collectors.tasks.run_collectors_by_type',
+        'schedule': timedelta(minutes=5),
+        'args': ('ga-realtime', 'piwik-realtime')
+    },
+    'daily': {
+        'task': 'stagecraft.apps.collectors.tasks.run_collectors_by_type',
+        'schedule': crontab(minute=0, hour=0),
+        'args': (
+            'ga',
+            'ga-contrib-content-table',
+            'ga-trending',
+            'gcloud',
+            'pingdom',
+            'piwik-core',
+            'webtrends-keymetrics',
+            'webtrends-reports'
+        )
+    },
+}
 
 ROLES = [
     {


### PR DESCRIPTION
Use Celery periodic tasks to run collectors rather than a crontab file.

Note - Two tasks are defined in this pull request, one for Google Analytics and Piwik realtime tasks (run every 5 minutes) and one for all other collectors (run at midnight each day).

Story: https://www.pivotaltracker.com/story/show/100638186
