### PR TITLE
Suppress non-realtime collector jobs

### DIFF
--- a/stagecraft/settings/common.py
+++ b/stagecraft/settings/common.py
@@ -143,21 +143,21 @@ CELERYBEAT_SCHEDULE = {
         'schedule': timedelta(minutes=5),
         'args': ('ga-realtime', 'piwik-realtime')
     },
-    'daily': {
-        'task': 'stagecraft.apps.collectors.tasks.run_collectors_by_type',
-        'schedule': crontab(minute=0, hour=0),
-        'args': (
-            'ga',
-            'ga-contrib-content-table',
-            'ga-trending',
-            'gcloud',
-            'pingdom',
-            'piwik-core',
-            'webtrends-keymetrics',
-            'webtrends-reports'
-        )
-    },
 }
+#    'daily': {
+#        'task': 'stagecraft.apps.collectors.tasks.run_collectors_by_type',
+#        'schedule': crontab(minute=0, hour=0),
+#        'args': (
+#            'ga',
+#            'ga-contrib-content-table',
+#            'ga-trending',
+#            'gcloud',
+#            'pingdom',
+#            'piwik-core',
+#            'webtrends-keymetrics',
+#            'webtrends-reports'
+#        )
+#    },
 
 ROLES = [
     {


### PR DESCRIPTION
We don't want to run all collectors using Celery periodic tasks to begin with. Rather we want
to first confirm that real-time collectors run okay.

Note - merge/release at the same time as https://github.com/alphagov/performanceplatform-collector-config/pull/235