### PR TITLE
Add a setting to disable collectors

### DIFF
--- a/stagecraft/apps/collectors/tasks.py
+++ b/stagecraft/apps/collectors/tasks.py
@@ -60,4 +60,7 @@ def run_collector(collector_slug, start_at=None, end_at=None, dry_run=False):
         return collector.type.entry_point, config
 
     entry_point, args = get_config(collector_slug, start_at, end_at)
-    _run_collector(entry_point, args)
+    if settings.DISABLE_COLLECTORS:
+        return 'Collectors Disabled'
+    else:
+        _run_collector(entry_point, args)

--- a/stagecraft/settings/common.py
+++ b/stagecraft/settings/common.py
@@ -263,3 +263,5 @@ ROLES = [
         },
     },
 ]
+
+DISABLE_COLLECTORS = False


### PR DESCRIPTION
When running from cron, collectors were disabled from running on preview
and staging due to google api rate limits. This setting will let us
disable the collectors on staging and preview.