### PR TITLE
Run all collectors as Celery periodic tasks

### DIFF
--- a/stagecraft/settings/common.py
+++ b/stagecraft/settings/common.py
@@ -143,21 +143,25 @@ CELERYBEAT_SCHEDULE = {
         'schedule': timedelta(minutes=5),
         'args': ('ga-realtime', 'piwik-realtime')
     },
+    'hourly': {
+        'task': 'stagecraft.apps.collectors.tasks.run_collectors_by_type',
+        'schedule': timedelta(hours=1),
+        'args': ('pingdom')
+    },
+    'daily': {
+        'task': 'stagecraft.apps.collectors.tasks.run_collectors_by_type',
+        'schedule': crontab(minute=0, hour=0),
+        'args': (
+            'ga',
+            'ga-contrib-content-table',
+            'ga-trending',
+            'gcloud',
+            'piwik-core',
+            'webtrends-keymetrics',
+            'webtrends-reports'
+        )
+    },
 }
-#    'daily': {
-#        'task': 'stagecraft.apps.collectors.tasks.run_collectors_by_type',
-#        'schedule': crontab(minute=0, hour=0),
-#        'args': (
-#            'ga',
-#            'ga-contrib-content-table',
-#            'ga-trending',
-#            'gcloud',
-#            'pingdom',
-#            'piwik-core',
-#            'webtrends-keymetrics',
-#            'webtrends-reports'
-#        )
-#    },
 
 ROLES = [
     {


### PR DESCRIPTION
After successfully running realtime collectors using Celery periodic tasks, we now want to run all collectors using this approach.