### PR TITLE
Fix Celery periodic tasks settings

### DIFF
--- a/stagecraft/settings/common.py
+++ b/stagecraft/settings/common.py
@@ -146,7 +146,7 @@ CELERYBEAT_SCHEDULE = {
     'hourly': {
         'task': 'stagecraft.apps.collectors.tasks.run_collectors_by_type',
         'schedule': timedelta(hours=1),
-        'args': ('pingdom')
+        'args': ('pingdom',)
     },
     'daily': {
         'task': 'stagecraft.apps.collectors.tasks.run_collectors_by_type',


### PR DESCRIPTION
The hourly Celery periodic tasks were not running due to a missing comma in the settings. This might also have caused the daily tasks not to run.