### PR TITLE
Route collector logging to /log

### DIFF
--- a/requirements/_common.txt
+++ b/requirements/_common.txt
@@ -29,4 +29,4 @@ dogslow==0.9.7
 oauth2client==1.4.11
 
 # To query for data from google analytics, webtrends, pingdom etc
-performanceplatform-collector==0.2.4
+performanceplatform-collector==0.2.5

--- a/stagecraft/apps/collectors/tasks.py
+++ b/stagecraft/apps/collectors/tasks.py
@@ -56,7 +56,8 @@ def run_collector(collector_slug, start_at=None, end_at=None, dry_run=False):
             },
             dry_run=dry_run,
             start_at=(datetime.strptime(start, '%Y-%m-%d') if start else None),
-            end_at=(datetime.strptime(end, '%Y-%m-%d') if end else None)
+            end_at=(datetime.strptime(end, '%Y-%m-%d') if end else None),
+            console_logging=False
         )
         return collector.type.entry_point, config
 
@@ -64,4 +65,5 @@ def run_collector(collector_slug, start_at=None, end_at=None, dry_run=False):
     if settings.DISABLE_COLLECTORS:
         return 'Collectors Disabled'
     else:
-        _run_collector(entry_point, args)
+        logfile_path = settings.BASE_DIR + "/log"
+        _run_collector(entry_point, args, logfile_path, 'collectors')


### PR DESCRIPTION
When running collectors via Stagecraft, log all collector output to /log directory, rather than the /log directory of performanceplatform-collector.

Story: https://www.pivotaltracker.com/story/show/105753440