### PR TITLE
Make capped_size field on DataSet editable

### DIFF
--- a/stagecraft/apps/datasets/admin/data_set.py
+++ b/stagecraft/apps/datasets/admin/data_set.py
@@ -66,7 +66,7 @@ class DataSetAdmin(reversion.VersionAdmin):
     change_form_template = 'data_set/change_form.html'
 
     readonly_after_created = set(
-        ['name', 'data_group', 'data_type', 'capped_size'])
+        ['name', 'data_group', 'data_type'])
     readonly_fields = ('name', )
     search_fields = ['name']
     list_display = ('name', 'data_group', 'data_type', 'data_location',

--- a/stagecraft/apps/datasets/models/data_set.py
+++ b/stagecraft/apps/datasets/models/data_set.py
@@ -53,7 +53,7 @@ class DataSet(models.Model):
     # used in clean() below to prevent ORM model changes like
     # e.g. modifying a name after the data_set has been created
     READONLY_AFTER_CREATED = set(
-        ['name', 'capped_size'])
+        ['name'])
 
     objects = DataSetManager()
 

--- a/stagecraft/apps/datasets/tests/models/test_data_set.py
+++ b/stagecraft/apps/datasets/tests/models/test_data_set.py
@@ -161,20 +161,6 @@ class DataSetTestCase(TestCase):
             data_group=self.data_group1,
             data_type=self.data_type1)
 
-    def test_capped_size_cannot_be_changed(self):
-        data_set = DataSet.objects.create(
-            data_group=self.data_group1,
-            data_type=self.data_type1)
-
-        data_set.capped_size = 42
-        assert_raises(ImmutableFieldError, data_set.save)
-
-    def test_capped_size_can_be_set_on_creation(self):
-        DataSet.objects.create(
-            data_group=self.data_group1,
-            data_type=self.data_type1,
-            capped_size=42)
-
     def test_cant_delete_referenced_data_group(self):
         refed_data_group = DataGroup.objects.create(name='refed_data_group')
         DataSet.objects.create(
@@ -209,13 +195,6 @@ class DataSetTestCase(TestCase):
             data_group=self.data_group1,
             data_type=self.data_type1)
         data_set.name = "abc"
-        assert_raises(ImmutableFieldError, lambda: data_set.clean())
-
-    def test_clean_raise_immutablefield_cappedsize_change(self):
-        data_set = DataSet.objects.create(
-            data_group=self.data_group1,
-            data_type=self.data_type1)
-        data_set.capped_size = 1000
         assert_raises(ImmutableFieldError, lambda: data_set.clean())
 
     def test_clean_not_raise_immutablefield_no_change(self):


### PR DESCRIPTION
Remove config and validation that prevents the capped_size field on DataSet from being changed in Django Admin after a data set has been created.

Story: https://www.pivotaltracker.com/story/show/95028694 