### PR TITLE
Display content of lists and menus in alphabetical order

### DIFF
--- a/stagecraft/apps/collectors/admin.py
+++ b/stagecraft/apps/collectors/admin.py
@@ -140,3 +140,5 @@ class CollectorAdmin(admin.ModelAdmin):
 @admin.register(models.DataSource)
 class DataSourceAdmin(admin.ModelAdmin):
     filter_horizontal = ('owners',)
+    list_display = ('slug', 'name')
+    ordering = ('slug', )

--- a/stagecraft/apps/organisation/admin.py
+++ b/stagecraft/apps/organisation/admin.py
@@ -21,6 +21,7 @@ class NodeAdmin(admin.ModelAdmin):
     search_fields = ('name', 'abbreviation',)
     inlines = (ParentInline,)
     exclude = ('parents',)
+    ordering = ('name', )
 
 
 admin.site.register(NodeType, NodeTypeAdmin)

--- a/stagecraft/apps/transforms/admin.py
+++ b/stagecraft/apps/transforms/admin.py
@@ -11,6 +11,12 @@ class TransformAdmin(admin.ModelAdmin):
     list_display = (
         'input_group', 'input_type', 'output_group', 'output_type',)
     filter_horizontal = ('owners',)
+    search_fields = (
+        'input_group__name',
+        'input_type__name',
+        'output_group__name',
+        'output_type__name',)
+    ordering = ('input_group', 'input_type', 'output_group', 'output_type',)
 
 
 admin.site.register(TransformType, TransformTypeAdmin)


### PR DESCRIPTION
Order Datasources by slug in django admin.

Order Nodes (Organisations) by name in django admin

Add search filter to Transforms in Django Admin

Allow filtering by:
* input data group
* input data type
* output data group
* output data type

Add ordering to Transforms on Django Admin

Display Transforms in the following order
1. input group
2. input type
3. output group
4. output type

Pivotal: https://www.pivotaltracker.com/story/show/95028568