### PR TITLE
Bump performance platform collector library

### DIFF
--- a/requirements/_common.txt
+++ b/requirements/_common.txt
@@ -29,4 +29,4 @@ dogslow==0.9.7
 oauth2client==1.4.11
 
 # To query for data from google analytics, webtrends, pingdom etc
-performanceplatform-collector==0.2.5
+performanceplatform-collector==0.2.6


### PR DESCRIPTION
Get the latest version of the performance platform collector library so as to start rotating log files. See https://github.com/alphagov/performanceplatform-collector/pull/142 