### PR TITLE
Bump performanceplatform-collector library to 0.2.8

### DIFF
--- a/requirements/_common.txt
+++ b/requirements/_common.txt
@@ -29,4 +29,4 @@ dogslow==0.9.7
 oauth2client==1.4.11
 
 # To query for data from google analytics, webtrends, pingdom etc
-performanceplatform-collector==0.2.7
+performanceplatform-collector==0.2.8


### PR DESCRIPTION
Version 0.2.8 contains code to release logging resources which will hopefully resolve an issue in production where file descriptors for log files are not being released after a collector is run.