### PR TITLE
Extend user admin form to assign data sets

### DIFF
--- a/stagecraft/apps/datasets/models/data_set.py
+++ b/stagecraft/apps/datasets/models/data_set.py
@@ -71,7 +71,8 @@ class DataSet(models.Model):
                                    verbose_name='created (UTC)')
     modified = models.DateTimeField(auto_now=True,
                                     verbose_name='modified (UTC)')
-    owners = models.ManyToManyField('users.User', blank=True)
+    owners = models.ManyToManyField(
+        'users.User', blank=True, related_name='data_sets')
     data_group = models.ForeignKey(
         DataGroup,
         on_delete=models.PROTECT,

--- a/stagecraft/apps/datasets/views/data_set.py
+++ b/stagecraft/apps/datasets/views/data_set.py
@@ -162,7 +162,7 @@ def dashboard(user, request, name):
 def users(user, request, dataset_name):
 
     users = User.objects.filter(
-        dataset__name=dataset_name
+        data_sets__name=dataset_name
     )
 
     if users:

--- a/stagecraft/apps/users/admin.py
+++ b/stagecraft/apps/users/admin.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from django.contrib import admin
-from django.db import models
+from django import forms
 import reversion
 from stagecraft.apps.users.models import User
 from stagecraft.apps.datasets.models.data_set import DataSet
@@ -12,9 +12,32 @@ class DataSetInline(admin.StackedInline):
     extra = 0
 
 
+class UserAdminForm(forms.ModelForm):
+    data_sets = forms.ModelMultipleChoiceField(
+        DataSet.objects.all(),
+        widget=admin.widgets.FilteredSelectMultiple('Data sets', False),
+        required=False,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super(UserAdminForm, self).__init__(*args, **kwargs)
+        if self.instance.pk:
+            self.initial['data_sets'] = self.instance.data_sets.values_list(
+                'pk', flat=True)
+
+    def save(self, *args, **kwargs):
+        instance = super(UserAdminForm, self).save(*args, **kwargs)
+        if instance.pk:
+            instance.data_sets.clear()
+            instance.data_sets.add(*self.cleaned_data['data_sets'])
+        return instance
+
+
 class UserAdmin(reversion.VersionAdmin):
     search_fields = ['email']
     list_display = ('email',)
     list_per_page = 30
+
+    form = UserAdminForm
 
 admin.site.register(User, UserAdmin)

--- a/stagecraft/apps/users/management/commands/import_users_from_backdrop.py
+++ b/stagecraft/apps/users/management/commands/import_users_from_backdrop.py
@@ -42,7 +42,7 @@ class Command(BaseCommand):
                 email=email,
             )
             for data_set in data_sets:
-                user.dataset_set.add(data_set)
+                user.data_sets.add(data_set)
                 self.stdout.write(
                     "Added access to {0} for user {1}".format(data_set, email)
                 )

--- a/stagecraft/apps/users/tests/management/commands/test_import_users_from_backdrop.py
+++ b/stagecraft/apps/users/tests/management/commands/test_import_users_from_backdrop.py
@@ -11,12 +11,12 @@ class TestImportBackdropUser(TestCase):
 
     def setUp(self):
         for user in User.objects.all():
-            user.dataset_set.clear()
+            user.data_sets.clear()
             user.delete()
 
     def tearDown(self):
         for user in User.objects.all():
-            user.dataset_set.clear()
+            user.data_sets.clear()
             user.delete()
 
     def test_raises_command_error_when_no_user_file_passed(
@@ -49,7 +49,7 @@ users/tests/fixtures/backdrop_users_import_testdata.json"]
             return User.objects.filter(email=email).first()
 
         def _get_data_set_names(user):
-            return set([data_set.name for data_set in user.dataset_set.all()])
+            return set([data_set.name for data_set in user.data_sets.all()])
 
         args = ["stagecraft/apps/\
 users/tests/fixtures/backdrop_users_import_testdata.json"]


### PR DESCRIPTION
Enable the adding of data sets from the user admin form in Django Admin.

Story: https://www.pivotaltracker.com/story/show/100714550