### PR TITLE
Disable dataset delete

### DIFF
--- a/stagecraft/apps/dashboards/models/dashboard.py
+++ b/stagecraft/apps/dashboards/models/dashboard.py
@@ -2,9 +2,9 @@ from __future__ import unicode_literals
 import uuid
 from django.core.validators import RegexValidator
 from django.db import models
+from stagecraft.apps.organisation.models import Node
 
 from stagecraft.apps.users.models import User
-from stagecraft.apps.organisation.views import NodeView
 from django.db.models.query import QuerySet
 
 
@@ -279,7 +279,7 @@ class Dashboard(models.Model):
             serialized['published'] = False
 
         if self.organisation:
-            serialized['organisation'] = NodeView.serialize(self.organisation)
+            serialized['organisation'] = Node.serialize(self.organisation)
         else:
             serialized['organisation'] = None
 

--- a/stagecraft/apps/dashboards/models/module.py
+++ b/stagecraft/apps/dashboards/models/module.py
@@ -10,8 +10,6 @@ from django.db import models
 from dbarray import TextArrayField
 from jsonfield import JSONField
 
-from stagecraft.apps.datasets.models import DataSet
-
 from .dashboard import Dashboard
 
 
@@ -68,7 +66,7 @@ class Module(models.Model):
     id = models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True)
     type = models.ForeignKey(ModuleType)
     dashboard = models.ForeignKey(Dashboard)
-    data_set = models.ForeignKey(DataSet, null=True, blank=True)
+    data_set = models.ForeignKey('datasets.DataSet', null=True, blank=True)
     parent = models.ForeignKey("self", null=True, blank=True)
 
     slug_validator = RegexValidator(

--- a/stagecraft/apps/datasets/models/data_set.py
+++ b/stagecraft/apps/datasets/models/data_set.py
@@ -272,6 +272,29 @@ class DataSet(models.Model):
             self.data_group.name,
             self.data_type.name)
 
+    def _get_tabbed_modules(self):
+        modules = []
+
+        from stagecraft.apps.dashboards.models import Module
+        for m in Module.objects.filter(type__name='tab'):
+            for tab in m.options['tabs']:
+                if (tab['data-source']['data-group'] ==
+                        self.data_group.name) \
+                        and (tab['data-source']['data-type'] ==
+                             self.data_type.name):
+                    modules.append(m)
+        return modules
+
+    @property
+    def modules(self):
+        modules = []
+        for m in self.module_set.all():
+            modules.append(m)
+
+        modules.extend(self._get_tabbed_modules())
+
+        return modules
+
     @property
     def is_capped(self):
         # Actually mongo's limit for cap size minimum is currently 4096 :-(

--- a/stagecraft/apps/datasets/models/data_set.py
+++ b/stagecraft/apps/datasets/models/data_set.py
@@ -19,6 +19,8 @@ from stagecraft.libs.schemas import get_schema
 
 from ..helpers.validators import data_set_name_validator
 
+from stagecraft.apps.dashboards.models import Module
+
 import reversion
 import logging
 
@@ -275,7 +277,6 @@ class DataSet(models.Model):
     def _get_tabbed_modules(self):
         modules = []
 
-        from stagecraft.apps.dashboards.models import Module
         for m in Module.objects.filter(type__name='tab'):
             for tab in m.options['tabs']:
                 if (tab['data-source']['data-group'] ==

--- a/stagecraft/apps/datasets/static/admin/css/datasets.css
+++ b/stagecraft/apps/datasets/static/admin/css/datasets.css
@@ -1,3 +1,10 @@
 #id_bearer_token {
   margin-right: 1em;
 }
+
+form ul.columns {
+  column-count: 2;
+  -webkit-column-count: 2;
+  -moz-column-count: 2;
+}
+

--- a/stagecraft/apps/datasets/templates/data_set/change_form.html
+++ b/stagecraft/apps/datasets/templates/data_set/change_form.html
@@ -9,13 +9,15 @@
 {% endblock %}
 
 {% block after_related_objects %}
-{% if dashboards %}
+{% if dashboard_titles %}
   <fieldset class="module aligned">
     <div class="form-row">
       <label>Linked dashboards:</label>
-      {% for dashboard in dashboards %}
-        <p>{{ dashboard }}</p>
+      <ul class="columns">
+      {% for title in dashboard_titles %}
+        <li>{{ title }}</li>
       {% endfor %}
+      </ul>
       <p class="help">These dashboards need to be unpublished before the data set can be deleted</p>
     </div>
   </fieldset>

--- a/stagecraft/apps/datasets/templates/data_set/change_form.html
+++ b/stagecraft/apps/datasets/templates/data_set/change_form.html
@@ -6,4 +6,18 @@
     <input type="submit" value="{% trans 'Empty dataset' %}" name="_empty_dataset" />
   </div>
   {% submit_row %}
-{% endblock %} 
+{% endblock %}
+
+{% block after_related_objects %}
+{% if dashboards %}
+  <fieldset class="module aligned">
+    <div class="form-row">
+      <label>Linked dashboards:</label>
+      {% for dashboard in dashboards %}
+        <p>{{ dashboard }}</p>
+      {% endfor %}
+      <p class="help">These dashboards need to be unpublished before the data set can be deleted</p>
+    </div>
+  </fieldset>
+{% endif %}
+{% endblock %}

--- a/stagecraft/apps/datasets/tests/admin/test_data_set.py
+++ b/stagecraft/apps/datasets/tests/admin/test_data_set.py
@@ -1,14 +1,10 @@
 from django.http import HttpRequest, HttpResponseRedirect
 from hamcrest import (
-    assert_that, is_, instance_of, contains_string,
-    equal_to)
+    assert_that, is_, instance_of, contains_string)
 from httmock import urlmatch, HTTMock
 from unittest import TestCase
-from stagecraft.apps.dashboards.tests.factories.factories import \
-    DashboardFactory, ModuleFactory
 
-from stagecraft.apps.datasets.admin.data_set import DataSetAdmin, \
-    get_published_dashboards
+from stagecraft.apps.datasets.admin.data_set import DataSetAdmin
 from stagecraft.apps.datasets.tests.factories import DataSetFactory
 
 
@@ -46,23 +42,3 @@ class DataSetAdminTestCase(TestCase):
         )))
         assert_that(response, instance_of(HttpResponseRedirect))
         assert_that(str(response.url), contains_string(str(dataset.pk)))
-
-    def test_data_set_linked_to_published_dashboard(self):
-        data_set = DataSetFactory()
-        dashboard = DashboardFactory(status="published")
-        ModuleFactory(data_set=data_set, dashboard=dashboard)
-
-        assert_that(get_published_dashboards(data_set.name),
-                    equal_to([dashboard.title]))
-
-    def test_data_set_linked_to_unpublished_dashboard(self):
-        data_set = DataSetFactory()
-        dashboard = DashboardFactory(status="unpublished")
-        ModuleFactory(data_set=data_set, dashboard=dashboard)
-
-        assert_that(get_published_dashboards(data_set.name), equal_to([]))
-
-    def test_data_set_not_linked_to_dashboard(self):
-        data_set = DataSetFactory()
-
-        assert_that(get_published_dashboards(data_set.name), equal_to([]))

--- a/stagecraft/apps/datasets/tests/admin/test_data_set.py
+++ b/stagecraft/apps/datasets/tests/admin/test_data_set.py
@@ -1,11 +1,14 @@
 from django.http import HttpRequest, HttpResponseRedirect
 from hamcrest import (
-    assert_that, is_, instance_of, contains_string
-)
+    assert_that, is_, instance_of, contains_string,
+    equal_to)
 from httmock import urlmatch, HTTMock
 from unittest import TestCase
+from stagecraft.apps.dashboards.tests.factories.factories import \
+    DashboardFactory, ModuleFactory
 
-from stagecraft.apps.datasets.admin.data_set import DataSetAdmin
+from stagecraft.apps.datasets.admin.data_set import DataSetAdmin, \
+    get_published_dashboards
 from stagecraft.apps.datasets.tests.factories import DataSetFactory
 
 
@@ -43,3 +46,23 @@ class DataSetAdminTestCase(TestCase):
         )))
         assert_that(response, instance_of(HttpResponseRedirect))
         assert_that(str(response.url), contains_string(str(dataset.pk)))
+
+    def test_data_set_linked_to_published_dashboard(self):
+        data_set = DataSetFactory()
+        dashboard = DashboardFactory(status="published")
+        ModuleFactory(data_set=data_set, dashboard=dashboard)
+
+        assert_that(get_published_dashboards(data_set.name),
+                    equal_to([dashboard.title]))
+
+    def test_data_set_linked_to_unpublished_dashboard(self):
+        data_set = DataSetFactory()
+        dashboard = DashboardFactory(status="unpublished")
+        ModuleFactory(data_set=data_set, dashboard=dashboard)
+
+        assert_that(get_published_dashboards(data_set.name), equal_to([]))
+
+    def test_data_set_not_linked_to_dashboard(self):
+        data_set = DataSetFactory()
+
+        assert_that(get_published_dashboards(data_set.name), equal_to([]))

--- a/stagecraft/apps/organisation/models.py
+++ b/stagecraft/apps/organisation/models.py
@@ -54,6 +54,12 @@ class NodeType(models.Model):
     def __str__(self):
         return "{}".format(self.name)
 
+    def serialize(self):
+        return {
+            'id': str(self.id),
+            'name': self.name
+        }
+
 
 class Node(models.Model):
 
@@ -83,6 +89,24 @@ class Node(models.Model):
 
     def __str__(self):
         return self.name.encode('utf-8')
+
+    def serialize(self):
+        node = {
+            'id': str(self.id),
+            'type': {
+                'id': str(self.typeOf.id),
+                'name': self.typeOf.name
+            },
+            'name': self.name,
+            'slug': self.slug,
+        }
+
+        if self.abbreviation is not None:
+            node['abbreviation'] = self.abbreviation
+        else:
+            node['abbreviation'] = self.name
+
+        return node
 
     def get_ancestors(self, include_self=True):
         return Node.objects.ancestors_of(self, include_self)

--- a/stagecraft/apps/organisation/views.py
+++ b/stagecraft/apps/organisation/views.py
@@ -30,10 +30,7 @@ class NodeTypeView(ResourceView):
 
     @staticmethod
     def serialize(model):
-        return {
-            'id': str(model.id),
-            'name': model.name
-        }
+        return model.serialize()
 
 
 class NodeView(ResourceView):
@@ -103,19 +100,7 @@ class NodeView(ResourceView):
 
     @staticmethod
     def serialize(model):
-        node = {
-            'id': str(model.id),
-            'type': NodeTypeView.serialize(model.typeOf),
-            'name': model.name,
-            'slug': model.slug,
-        }
-
-        if model.abbreviation is not None:
-            node['abbreviation'] = model.abbreviation
-        else:
-            node['abbreviation'] = model.name
-
-        return node
+        return model.serialize()
 
 
 NodeView.sub_resources = {


### PR DESCRIPTION
Stagecraft should be able to determine whether a dataset is used in a published or unpublished dashboard and whether 'orphaned'. Default behaviour is that only orphaned datasets can be deleted. Override should be allowable to datasets in unpublished dashboards to be deleted. datasets used in published dashboards must not be able to be deleted.

Added a check on the django admin change form for the data set. If the dataset is linked to a dashboard that is published, the delete data set button is disabled, and a list of linked dashboards is displayed to the user.

Pivotal: https://www.pivotaltracker.com/story/show/95029022