### PR TITLE
Make Link model editable in Django Admin

### DIFF
--- a/stagecraft/apps/dashboards/admin/dashboard.py
+++ b/stagecraft/apps/dashboards/admin/dashboard.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from django.contrib import admin
-from stagecraft.apps.dashboards.models import Dashboard
+from stagecraft.apps.dashboards.models import Dashboard, Link
 
 
 class DashboardAdmin(admin.ModelAdmin):
@@ -9,5 +9,15 @@ class DashboardAdmin(admin.ModelAdmin):
     fields = ('title', 'owners')
     readonly_fields = ('title',)
     filter_horizontal = ('owners',)
+    search_fields = ['title']
 
 admin.site.register(Dashboard, DashboardAdmin)
+
+
+class LinkAdmin(admin.ModelAdmin):
+    list_display = ('title', 'link_url', 'link_type', 'dashboard')
+    ordering = ('title',)
+    fields = ('title', 'url', 'link_type', 'dashboard',)
+    search_fields = ['title']
+
+admin.site.register(Link, LinkAdmin)

--- a/stagecraft/apps/dashboards/models/dashboard.py
+++ b/stagecraft/apps/dashboards/models/dashboard.py
@@ -290,6 +290,9 @@ class Dashboard(models.Model):
 
         return serialized
 
+    def __str__(self):
+        return self.slug
+
     def serialized_modules(self):
         return [m.serialize()
                 for m in self.module_set.filter(parent=None).order_by('order')]
@@ -390,6 +393,10 @@ class Link(models.Model):
         max_length=20,
         choices=list_to_tuple_pairs(link_types),
     )
+
+    def link_url(self):
+        return '<a href="{0}">{0}</a>'.format(self.url)
+    link_url.allow_tags = True
 
     def serialize(self):
         return {


### PR DESCRIPTION
Other links, to things like policies and publications are not
editable in performanceplatform-admin. It seems that these links were
added to some of the site activity dashboards in the early days of
performance platform, when the config for dashboards was stored in as
json files in the spotlight-config repo.

The contents of spotlight-config was then migrated to stagecraft using the
spotlight_config_migration script. This script is the only place I could find
where links are actively added to dashboards.

It is possible to add other links to a dashboard by using the stagecraft api,
but as they are not included in the post data from performanceplatform-admin,
it can be assumed that these links are no longer supported.

A zendesk ticket was raised recently because to the link to the Environment
Agency's policies are incorrect. We need a way to update any other links a
dashboard may have to fix the zendesk ticket, before deciding if it is worth
adding extra functionality to the admin/self-serve app.

Zendesk ticket: 1190780