### PR TITLE
Transaction Explorer spreadsheet column changes

### DIFF
--- a/stagecraft/tools/fixtures/tx.json
+++ b/stagecraft/tools/fixtures/tx.json
@@ -1,11 +1,10 @@
-[  
+[
   [
     "Abbr",
     "Department",
     "Agency/body",
     "Agency abbr",
     "Name of service",
-    "Short service name",
     "Slug",
     "2012-Q4 Vol.",
     "2012-Q4 CPT (\u00a3)",
@@ -70,7 +69,6 @@
     "Service link text",
     "Description of service",
     "Description 1",
-    "Description 2",
     "Single description (for template)",
     "Notes on costs",
     "Other notes",
@@ -134,10 +132,8 @@
     "Treasury Solicitor's Department",
     "TSOL",
     "Bona vacantia: referrals of estates and company assets",
-    "Bona vacantia",
     "ago-bona-vacantia-referrals-of-estates-company-assets",
     "40000",
-    "",
     "",
     "",
     "",

--- a/stagecraft/tools/fixtures/tx_no_agency_abbr.json
+++ b/stagecraft/tools/fixtures/tx_no_agency_abbr.json
@@ -1,11 +1,10 @@
-[  
+[
   [
     "Abbr",
     "Department",
     "Agency/body",
     "Agency abbr",
     "Name of service",
-    "Short service name",
     "Slug",
     "2012-Q4 Vol.",
     "2012-Q4 CPT (\u00a3)",
@@ -70,7 +69,6 @@
     "Service link text",
     "Description of service",
     "Description 1",
-    "Description 2",
     "Single description (for template)",
     "Notes on costs",
     "Other notes",
@@ -134,10 +132,8 @@
     "Treasury Solicitor's Department",
     "",
     "Bona vacantia: referrals of estates and company assets",
-    "Bona vacantia",
     "ago-bona-vacantia-referrals-of-estates-company-assets",
     "40000",
-    "",
     "",
     "",
     "",

--- a/stagecraft/tools/spreadsheets.py
+++ b/stagecraft/tools/spreadsheets.py
@@ -24,9 +24,7 @@ class SpreadsheetMunger:
         # "Name of service",
         self.tx_name = positions.get('tx_name', 4)
         # "Description 1",
-        self.tx_desc1 = positions.get('tx_desc1', 69)
-        # "Description 2",
-        self.tx_desc2 = positions.get('tx_desc2', 70)
+        self.tx_desc1 = positions.get('tx_desc1', 71)
         # "Agency abbr",
         self.tx_agency_abbr = positions.get('tx_agency_abbr', 3)
         # "Agency/body",
@@ -42,7 +40,7 @@ class SpreadsheetMunger:
         # "Other notes",
         self.tx_other_notes = positions.get('tx_other_notes', 73)
         # "Slug",
-        self.tx_tx_id_column = positions.get('tx_tx_id_column', 6)
+        self.tx_tx_id_column = positions.get('tx_tx_id_column', 5)
         # "Customer type",
         self.tx_customer_type = positions.get('tx_customer_type', 74)
         # "Business model",
@@ -76,8 +74,6 @@ class SpreadsheetMunger:
             record['name'] = row[self.tx_name]
         if row[self.tx_desc1]:
             record['description'] = row[self.tx_desc1]
-        if row[self.tx_desc2]:
-            record['description_extra'] = row[self.tx_desc2]
         if row[self.tx_costs]:
             record['costs'] = row[self.tx_costs]
         if row[self.tx_other_notes]:


### PR DESCRIPTION
The short service name and description 2 columns have been removed
from the source spreadsheet for transactions explorer. Adapted the
code to reflect the new column positions.