### PR TITLE
Bump performanceplatform-collector to 0.3.0

### DIFF
--- a/requirements/_common.txt
+++ b/requirements/_common.txt
@@ -29,4 +29,4 @@ dogslow==0.9.7
 oauth2client==1.5.2
 
 # To query for data from google analytics, webtrends, pingdom etc
-performanceplatform-collector==0.2.9
+performanceplatform-collector==0.3.0


### PR DESCRIPTION
The performanceplatform-collector library has been updated to fix a bug with the generation of credentials (see story: https://www.pivotaltracker.com/story/show/111132054).