### PR TITLE
Abbreviations longer than 50 characters cause import to fail

### DIFF
--- a/stagecraft/tools/import_organisations.py
+++ b/stagecraft/tools/import_organisations.py
@@ -288,15 +288,19 @@ def create_nodes(nodes, edges, type_to_NodeType):
     nodes_to_db = {}
     for node in nodes:
         slug = node[2]
+        abbr = node[3]
         if len(slug) > 150:
             print('slug too long "{}"'.format(slug))
             slug = slug[:150]
+        if abbr and len(abbr) > 50:
+            print('abbreviation too long "{}"'.format(abbr))
+            abbr = abbr[:50]
         db_node = Node(
             name=node[1].decode(
                 'utf-8').encode('latin1', 'ignore').decode('latin1'),
             slug=slug.decode(
                 'utf-8').encode('latin1', 'ignore').decode('latin1'),
-            abbreviation=node[3],
+            abbreviation=abbr,
             typeOf=type_to_NodeType[node[4]],
         )
         db_node.save()


### PR DESCRIPTION
Abbreviations longer than 50 characters in length cause the
import_organisations script to fail.

In the Node (organisation) model, the abbreviation field is limited
to 50 characters.

When the model is serialized or made ready for spotlight, if an
abbreviation does not exist, the name is passed back instead.
The name field allows upto 256 characters.

Have updated the import_organisations script until it is determined
whether of not it is safe to update the Node model.

Pivotal: https://www.pivotaltracker.com/story/show/110412434