### PR TITLE
Service ID missing from backdrop data causes import to fail

### DIFF
--- a/stagecraft/tools/import_dashboards.py
+++ b/stagecraft/tools/import_dashboards.py
@@ -141,6 +141,9 @@ def determine_modules_for_dashboard(summaries, tx_id):
         'transactions_per_year': True,
         'transactions_per_quarter': True
     }
+    for data in summaries:
+        if 'service_id' not in data:
+            data['service_id'] = data['dashboard_slug']
     service_data = [data for data in summaries if data['service_id'] == tx_id]
     quarterly_data = [datum for datum in service_data
                       if datum['type'] == 'quarterly']


### PR DESCRIPTION
Some dashboards are missing the service_id field in the data
retrieved from backdrop.

The missing field is in the digital_takeup data for all of the
dashboards.

As far as we can tell, the digital_takeup data has not been updated
since July 2015, though the dashboards on the frontend show data
through to December 2015.