### PR TITLE
Remove slug truncation from import_organisations script

### DIFF
--- a/stagecraft/tools/import_organisations.py
+++ b/stagecraft/tools/import_organisations.py
@@ -326,9 +326,6 @@ def link_transactions(nodes_to_transactions, nodes_to_db):
     for node, transactions in nodes_to_transactions.items():
         db_node = nodes_to_db[node]
         for transaction in transactions:
-            # duplicate the trimming that is done during import
-            if len(transaction) > 90:
-                transaction = transaction[:90]
             try:
                 dashboard = Dashboard.objects.get(slug=transaction)
                 dashboard.organisation = db_node


### PR DESCRIPTION
The Dashboard model used to limit the size of the slug to 90 characters.
This limit was changed to 1000 characters a while ago to accomodate the
slugs for BIS dashboards.

The import organisation script has been updated to reflect the change in
slug size.