### PR TITLE
Remove slug truncation from import_dashboards script

### DIFF
--- a/stagecraft/tools/spreadsheets.py
+++ b/stagecraft/tools/spreadsheets.py
@@ -241,9 +241,6 @@ class SpreadsheetMunger:
 
         if record.get('tx_id'):
             tx_id = self._replace_unicode(record['tx_id'])
-            if len(tx_id) > 90:
-                print('Truncated slug: {} to {}'.format(tx_id, tx_id[:90]))
-                record['tx_truncated'] = tx_id[:90]
             record['tx_id'] = tx_id
 
     def load(self, client_email, private_key):


### PR DESCRIPTION
The Dashboard model used to limit the size of the slug to 90 characters.
This limit was changed to 1000 characters a while ago to accomodate the
slugs for BIS dashboards.

The import dashboards script has been updated to reflect the change in
slug size.