### PR TITLE
Return the HTTP status code in the error

### DIFF
--- a/stagecraft/apps/dashboards/tests/views/test_dashboard.py
+++ b/stagecraft/apps/dashboards/tests/views/test_dashboard.py
@@ -133,7 +133,7 @@ class DashboardViewsListTestCase(TestCase):
             '/public/dashboards', {'slug': 'my_first_slug'})
         assert_that(json.loads(resp.content), equal_to(
             {
-                u'status': u'error',
+                u'status': 404,
                 u'message': u"No dashboard with slug 'my_first_slug' exists",
                 u'errors': [{
                     u'status': u'404',
@@ -265,7 +265,7 @@ class DashboardViewsListTestCase(TestCase):
         resp = self.client.get(
             '/public/dashboards', {'slug': 'my-first-slug/nonexisting-module'})
         data = json.loads(resp.content)
-        assert_that(data, has_entry('status', 'error'))
+        assert_that(data, has_entry('status', 404))
 
     def test_dashboard_with_tab_slug_only_returns_tab(self):
         dashboard = DashboardFactory(slug='my-first-slug')
@@ -371,7 +371,7 @@ class DashboardViewsListTestCase(TestCase):
             {'slug': 'my-first-slug/module/module-non-existent-tab'}
         )
         data = json.loads(resp.content)
-        assert_that(data, has_entry('status', 'error'))
+        assert_that(data, has_entry('status', 404))
 
 
 class DashboardViewsGetTestCase(TestCase):

--- a/stagecraft/apps/datasets/tests/support/test_helpers.py
+++ b/stagecraft/apps/datasets/tests/support/test_helpers.py
@@ -55,7 +55,7 @@ class IsErrorResponse(BaseMatcher):
     def _matches(self, response):
         try:
             data = json.loads(response.content.decode("utf-8"))
-            if data.get('status') != 'error':
+            if data.get('status') is None:
                 return False
             # it should not fail without a message
             if not data.get('message'):

--- a/stagecraft/libs/views/utils.py
+++ b/stagecraft/libs/views/utils.py
@@ -60,7 +60,7 @@ def create_error(request, status, code='', title='', detail=''):
 def create_http_error(status, message, request, code='', title='',
                       logger=None):
     error = {
-        'status': 'error',
+        'status': status,
         'message': message,
         'errors': [create_error(request,
                                 status,


### PR DESCRIPTION
The Error JSON used return a status of 'error' and nest the status code
further in the message. This causes problems for Kibana/Elastic Search
which expects the status field to contain a numerical status code.