### PR TITLE
Expose cache values

### DIFF
--- a/stagecraft/apps/dashboards/admin/dashboard.py
+++ b/stagecraft/apps/dashboards/admin/dashboard.py
@@ -6,7 +6,12 @@ from stagecraft.apps.dashboards.models import Dashboard, Link
 class DashboardAdmin(admin.ModelAdmin):
     list_display = ('title',)
     ordering = ('title',)
-    fields = ('title', 'owners')
+    fields = ('title',
+              'owners',
+              'department_cache',
+              'agency_cache',
+              'service_cache',
+              'transaction_cache')
     readonly_fields = ('title',)
     filter_horizontal = ('owners',)
     search_fields = ['title']


### PR DESCRIPTION
Stagecraft has two ways of returning the organisations that a dashboard
is linked to through its public API:

- https://stagecraft.production.performance.service.gov.uk/public/dashboards
- https://stagecraft.production.performance.service.gov.uk/public/dashboards?slug=bis-online-registration-to-participate-in-ukti-events

1. If the API is called without a slug, a method in the Dashboard view is called to return the
config for every published dashboard. This method gets the organisations
associated to the dashboard from the pre-filled "cache" database fields, e.g.
department_cache, agency_cache etc. This is how the department field is populated
on the services page rendered by Spotlight.

2. If the API is passed a dashboard slug, a different method in the Dashboard view is called
to get the config for a single dashboard. This method gets all of the organisations
linked to the dashboard on the fly and so returns the most up to date values.  This is how the
department field is populated on a dashboard page rendered by Spotlight.

The "cache" fields (mentioned in (1) above) are populated when the import_organisations script is run,
and thereafter never updated. This can lead to a discrepancy between items 1 and 2 - that is,  the services page can display a different department to the dashboard.

The quick fix is to expose the cached fields for each dashboard in django admin
so they can be updated one by one as we find mismatches. The proper fix is to
find a way to update these values whenever a relationship in the organisation
family tree changes.