### PR TITLE
Revert "Expose cache values"

### DIFF
--- a/stagecraft/apps/dashboards/admin/dashboard.py
+++ b/stagecraft/apps/dashboards/admin/dashboard.py
@@ -6,12 +6,7 @@ from stagecraft.apps.dashboards.models import Dashboard, Link
 class DashboardAdmin(admin.ModelAdmin):
     list_display = ('title',)
     ordering = ('title',)
-    fields = ('title',
-              'owners',
-              'department_cache',
-              'agency_cache',
-              'service_cache',
-              'transaction_cache')
+    fields = ('title', 'owners')
     readonly_fields = ('title',)
     filter_horizontal = ('owners',)
     search_fields = ['title']


### PR DESCRIPTION
Reverts alphagov/stagecraft#462

These changes are not needed.  The "cache" values are updated when the dashboard saved in the Admin app.