### PR TITLE
Add new organisation mapping

### DIFF
--- a/stagecraft/tools/import_organisations.py
+++ b/stagecraft/tools/import_organisations.py
@@ -36,7 +36,8 @@ govuk_to_pp_type = {
     "Other": 'agency',
     "Executive non-departmental public body": 'agency',
     "Independent monitoring body": 'agency',
-    "Public corporation": 'agency'
+    "Public corporation": 'agency',
+    "Ad-hoc advisory group": 'agency'
 }
 
 


### PR DESCRIPTION
This is required due to a new organisation (Ad-hoc advisory group) being added to the organisations api on 28th June 2016.