### PR TITLE
Update development-vm directory

### DIFF
--- a/tools/replicate-db.sh
+++ b/tools/replicate-db.sh
@@ -62,7 +62,7 @@ then
     vagrant ssh development-1 -c "sudo su postgres -c \"psql -c \\\"ALTER ROLE stagecraft WITH SUPERUSER\\\"\" -- -t"
     popd
 elif [ "$2" = 'govuk_dev' ]; then
-    pushd ../../govuk-puppet/development
+    pushd ../../govuk-puppet/development-vm
     vagrant ssh -c "sudo su postgres -c \"psql -c \\\"DROP DATABASE IF EXISTS stagecraft;\\\"\" -- -t"
     vagrant ssh -c "cd /var/govuk/stagecraft/tools && sudo su postgres -c \"gunzip -c ${FILENAME} | psql\" -- -t"
     vagrant ssh -c "sudo su postgres -c \"psql -c \\\"ALTER ROLE stagecraft WITH PASSWORD 'securem8'\\\"\" -- -t"


### PR DESCRIPTION
The gov.uk virtual machine now lives in the `development-vm` directory, so change it here so that the database replication works.

Update: tests are failing due to https://github.com/alphagov/stagecraft/issues/467

CC: @leelongmore 