### PR TITLE
Reduce log level in production

### DIFF
--- a/stagecraft/settings/production.py
+++ b/stagecraft/settings/production.py
@@ -73,7 +73,7 @@ LOGGING = {
             'class': 'django.utils.log.NullHandler',
         },
         'logfile': {
-            'level': 'DEBUG',
+            'level': 'WARNING',
             'class': 'logging.handlers.RotatingFileHandler',
             'filename': BASE_DIR + "/log/stagecraft.log",
             'maxBytes': 4 * 1024 * 1024,
@@ -82,7 +82,7 @@ LOGGING = {
             'filters': ['additional_fields'],
         },
         'json_log': {
-            'level': 'DEBUG',
+            'level': 'WARNING',
             'class': 'logging.FileHandler',
             'filename': BASE_DIR + "/log/production.json.log",
             'formatter': 'logstash_json',


### PR DESCRIPTION
In the last 24 hours, Stagecraft in production has logged 3.7 million of the 24 million log lines across all of GOV.UK. All but 614 of these are at INFO level, so setting the threshold to WARNING should remove the vast majority of our unnecessary logs in production.

https://docs.djangoproject.com/en/1.8/topics/logging/