### PR TITLE
Silence output on push

### DIFF
--- a/.travis_scripts/push_release_tag.sh
+++ b/.travis_scripts/push_release_tag.sh
@@ -88,10 +88,10 @@ function make_release_tag_from_travis_build_number {
 
   git checkout ${TRAVIS_COMMIT}
   git tag "${RELEASE_BRANCH_NAME}_${TRAVIS_BUILD_NUMBER}"
-  git push origin --tags --quiet
+  git push origin --tags --quiet > /dev/null 2>&1
 
   git tag --force "${RELEASE_BRANCH_NAME}"
-  git push --force origin --tags --quiet
+  git push --force origin --tags --quiet > /dev/null 2>&1
 
   popd
 }


### PR DESCRIPTION
Send `stdout` and `stderr` output to dev null so it does not appear in CI logs. If git push errors over https the output includes the GH auth token.