### PR TITLE
Change LOGGING.handlers in production settings

### DIFF
--- a/stagecraft/settings/production.py
+++ b/stagecraft/settings/production.py
@@ -68,7 +68,7 @@ LOGGING = {
     'handlers': {
         'null': {
             'level': 'INFO',
-            'class': 'django.utils.log.NullHandler',
+            'class': 'logging.NullHandler',
         },
         'logfile': {
             'level': 'WARNING',


### PR DESCRIPTION
Logging handler class was changed for latest Django version