### PR TITLE
Remove GOV.UK VM stuff from the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,25 +175,3 @@ migrate_data_set(mapping['old_data_set'],
 This will not delete the old data set. This should be done later when you are happy with the result.
 
 Tests which further specify the behaviour of this can be found in `test_copy_dataset_with_new_mapping.py`.
-
-# Running on gov.uk dev vm
-
-To run on the [gov.uk dev vm](https://github.gds/gds/puppet/tree/master/development),
-
-You will need to add a hosts entry in your /etc/hosts file for
-
-`192.168.185.152 stagecraft.dev.gov.uk`
-
-You will also need to sync data to the vm -
-
-`bash tools/replicate-db.sh api-postgresql-primary-1.api.integration govuk_dev`
-
-This will create the necessary database
-
-Then, change to the directory and run the start app script
-
-```
-cd /var/govuk/stagecraft
-./start-dev-app.sh
-```
-


### PR DESCRIPTION
Stagecraft was removed from `govuk-puppet`, so it no longer works with the GOV.UK VM.

Ref:
- https://github.com/alphagov/govuk-puppet/pull/6720
- https://github.com/alphagov/govuk-puppet/pull/6732
- https://github.com/alphagov/govuk-puppet/pull/6742