### PR TITLE
[159467985] Multi-user pingdom

### DIFF
--- a/requirements/_common.txt
+++ b/requirements/_common.txt
@@ -30,4 +30,4 @@ oauth2client==1.5.2
 performanceplatform-client==0.11.5
 
 # To query for data from google analytics, webtrends, pingdom etc
-performanceplatform-collector==0.3.1
+performanceplatform-collector==0.3.2


### PR DESCRIPTION
We have moved to using the GaaP pingdom account, which is using
multi-user Pingdom.

In order to make requests to the Pingdom API for multi-user accounts we
must pass the header 'Account-Email', the value of which is
'gaap-billing@digital.cabinet-office.gov.uk'.

0.3.2 is the version which has this update

solo @tlwr

Depends on https://github.com/alphagov/performanceplatform-collector/pull/153