### PR TITLE
bind new redis

### DIFF
--- a/etc/deploy.sh
+++ b/etc/deploy.sh
@@ -22,6 +22,11 @@ cf bind-service performance-platform-stagecraft-celery-worker redis-poc
 cf bind-service performance-platform-stagecraft-celery-beat redis-poc
 cf bind-service performance-platform-stagecraft-celery-cam redis-poc
 
+cf bind-service performance-platform-stagecraft-web redis
+cf bind-service performance-platform-stagecraft-celery-worker redis
+cf bind-service performance-platform-stagecraft-celery-beat redis
+cf bind-service performance-platform-stagecraft-celery-cam redis
+
 # set environmental variables
 cf set-env performance-platform-stagecraft-web SECRET_KEY $APP_SECRET_KEY
 cf set-env performance-platform-stagecraft-web FERNET_KEY $APP_FERNET_KEY

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,6 +5,7 @@ services:
   - logit-ssl-drain
   - gds-performance-platform-pg-service
   - redis-poc
+  - redis
 env:
   DEBUG: 0
   ENV_HOSTNAME: performance-platform-stagecraft.cloudapps.digital


### PR DESCRIPTION
there is a regular (not user provided) redis in staging and production.

this should be bound to the service but the credentials parsing code

will still use the old redis (redis-poc) so this is effectively a no-op

solo @tlwr