### PR TITLE
[159387416] Switch to using new redis

### DIFF
--- a/stagecraft/settings/common.py
+++ b/stagecraft/settings/common.py
@@ -50,8 +50,8 @@ def load_paas_settings():
         for service in vcap['postgres']:
             if service['name'] == 'gds-performance-platform-pg-service':
                 paas['DATABASE_URL'] = service['credentials']['uri']
-        for service in vcap['user-provided']:
-            if service['name'] == 'redis-poc':
+        for service in vcap['redis']:
+            if service['name'] == 'redis':
                 database_number = os.environ['REDIS_DATABASE_NUMBER']
                 url = service['credentials']['url']
                 url += '/' + database_number


### PR DESCRIPTION
No longer using a user-provided redis but instead using the officially
provided redis