### PR TITLE
Free manifest of deprecation warnings.

### DIFF
--- a/etc/deploy.sh
+++ b/etc/deploy.sh
@@ -15,20 +15,6 @@ sudo apt-get update && sudo apt-get install cf-cli
 
 cf login -u $PAAS_USER -p $PAAS_PASSWORD -a https://api.cloud.service.gov.uk -o gds-performance-platform -s $PAAS_SPACE
 
-# bind services
-cf bind-service performance-platform-stagecraft-web gds-performance-platform-pg-service
-cf bind-service performance-platform-stagecraft-web redis-poc
-cf bind-service performance-platform-stagecraft-celery-worker redis-poc
-cf bind-service performance-platform-stagecraft-celery-beat redis-poc
-cf bind-service performance-platform-stagecraft-celery-cam redis-poc
-cf bind-service performance-platform-stagecraft-flower redis-poc
-
-cf bind-service performance-platform-stagecraft-web redis
-cf bind-service performance-platform-stagecraft-celery-worker redis
-cf bind-service performance-platform-stagecraft-celery-beat redis
-cf bind-service performance-platform-stagecraft-celery-cam redis
-cf bind-service performance-platform-stagecraft-flower redis
-
 # set environmental variables
 cf set-env performance-platform-stagecraft-web SECRET_KEY $APP_SECRET_KEY
 cf set-env performance-platform-stagecraft-web FERNET_KEY $APP_FERNET_KEY
@@ -79,5 +65,4 @@ cf push -f manifest.yml
 
 # create and map routes
 cf map-route performance-platform-stagecraft-web cloudapps.digital --hostname performance-platform-stagecraft-$PAAS_SPACE
-cf delete-route cloudapps.digital --hostname performance-platform-stagecraft-flower-$PAAS_SPACE -f
 cf map-route performance-platform-stagecraft-flower cloudapps.digital --hostname performance-platform-stagecraft-flower-$PAAS_SPACE

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,51 +1,43 @@
 ---
-buildpack: https://github.com/cloudfoundry/python-buildpack.git#v1.5.24
-memory: 1G
-services:
-  - logit-ssl-drain
-  - gds-performance-platform-pg-service
-  - redis-poc
-  - redis
-env:
-  DEBUG: 0
-  ENV_HOSTNAME: performance-platform-stagecraft.cloudapps.digital
-  PUBLIC_HOSTNAME: performance-platform-stagecraft.cloudapps.digital
-  STATIC_URL: /assets/
+defaults: &defaults
+  buildpack: https://github.com/cloudfoundry/python-buildpack.git#v1.5.24
+  memory: 1G
+  no-route: true
+  health-check-type: none
+  instances: 1
+  services:
+    - logit-ssl-drain
+    - gds-performance-platform-pg-service
+    - redis-poc
+    - redis
+  env:
+    DEBUG: 0
+    ENV_HOSTNAME: performance-platform-stagecraft.cloudapps.digital
+    PUBLIC_HOSTNAME: performance-platform-stagecraft.cloudapps.digital
+    STATIC_URL: /assets/
 
 applications:
   - name: performance-platform-stagecraft-web
+    <<: *defaults
     command: python manage.py migrate && gunicorn stagecraft.wsgi:application --bind 0.0.0.0:$PORT --workers 4
     instances: 2
-    memory: 1G
-    no-route: true
-    health-check-type: none
 
   - name: performance-platform-stagecraft-celery-worker
+    <<: *defaults
     command: python manage.py celeryd --settings=$DJANGO_SETTINGS_MODULE -E -l debug
-    instances: 1
-    memory: 1G
-    no-route: true
-    health-check-type: none
 
   - name: performance-platform-stagecraft-celery-beat
+    <<: *defaults
     command: python manage.py celerybeat --settings=$DJANGO_SETTINGS_MODULE -l debug
-    instances: 1
-    no-route: true
     memory: 128M
-    health-check-type: none
 
   - name: performance-platform-stagecraft-celery-cam
+    <<: *defaults
     command: python manage.py celerycam --settings=$DJANGO_SETTINGS_MODULE
-    instances: 1
-    no-route: true
     memory: 128M
-    health-check-type: none
 
   - name: performance-platform-stagecraft-flower
+    <<: *defaults
     command: etc/run_flower.sh
-    instances: 1
-    memory: 1G
-    no-route: true
-    health-check-type: none
     env:
       DISABLE_COLLECTSTATIC: 1


### PR DESCRIPTION
Update the manifest to remove the deprecation warnings. Remove the now redundant lines from the deploy.sh script.
