### PR TITLE
Push, rather than start, the app after set-env.

### DIFF
--- a/etc/deploy.sh
+++ b/etc/deploy.sh
@@ -39,7 +39,7 @@ cf set-env performance-platform-stagecraft-web TRANSFORMED_DATA_SET_TOKEN $TRANS
 cf set-env performance-platform-stagecraft-web MIGRATION_SIGNON_TOKEN $MIGRATION_SIGNON_TOKEN
 cf set-env performance-platform-stagecraft-web DJANGO_SETTINGS_MODULE "stagecraft.settings.$PAAS_SPACE"
 # now rerun with the environment variables
-cf start performance-platform-stagecraft-web
+cf push performance-platform-stagecraft-web
 
 cycle_app performance-platform-stagecraft-celery-worker
 cf set-env performance-platform-stagecraft-celery-worker SECRET_KEY $APP_SECRET_KEY
@@ -50,7 +50,7 @@ cf set-env performance-platform-stagecraft-celery-worker GOVUK_WEBSITE_ROOT $GOV
 cf set-env performance-platform-stagecraft-celery-worker BACKDROP_PUBLIC_DOMAIN $BACKDROP_PUBLIC_DOMAIN
 cf set-env performance-platform-stagecraft-celery-worker REDIS_DATABASE_NUMBER $REDIS_DATABASE_NUMBER
 cf set-env performance-platform-stagecraft-celery-worker DJANGO_SETTINGS_MODULE "stagecraft.settings.$PAAS_SPACE"
-cf start performance-platform-stagecraft-celery-worker
+cf push performance-platform-stagecraft-celery-worker
 
 cycle_app performance-platform-stagecraft-celery-beat
 cf set-env performance-platform-stagecraft-celery-beat SECRET_KEY $APP_SECRET_KEY
@@ -61,7 +61,7 @@ cf set-env performance-platform-stagecraft-celery-beat GOVUK_WEBSITE_ROOT $GOVUK
 cf set-env performance-platform-stagecraft-celery-beat BACKDROP_PUBLIC_DOMAIN $BACKDROP_PUBLIC_DOMAIN
 cf set-env performance-platform-stagecraft-celery-beat REDIS_DATABASE_NUMBER $REDIS_DATABASE_NUMBER
 cf set-env performance-platform-stagecraft-celery-beat DJANGO_SETTINGS_MODULE "stagecraft.settings.$PAAS_SPACE"
-cf start performance-platform-stagecraft-celery-beat
+cf push performance-platform-stagecraft-celery-beat
 
 cycle_app performance-platform-stagecraft-celery-cam
 cf set-env performance-platform-stagecraft-celery-cam SECRET_KEY $APP_SECRET_KEY
@@ -72,12 +72,12 @@ cf set-env performance-platform-stagecraft-celery-cam GOVUK_WEBSITE_ROOT $GOVUK_
 cf set-env performance-platform-stagecraft-celery-cam BACKDROP_PUBLIC_DOMAIN $BACKDROP_PUBLIC_DOMAIN
 cf set-env performance-platform-stagecraft-celery-cam REDIS_DATABASE_NUMBER $REDIS_DATABASE_NUMBER
 cf set-env performance-platform-stagecraft-celery-cam DJANGO_SETTINGS_MODULE "stagecraft.settings.$PAAS_SPACE"
-cf start performance-platform-stagecraft-celery-cam
+cf push performance-platform-stagecraft-celery-cam
 
 cycle_app performance-platform-stagecraft-flower
 cf set-env performance-platform-stagecraft-flower REDIS_DATABASE_NUMBER $REDIS_DATABASE_NUMBER
 cf set-env performance-platform-stagecraft-flower FLOWER_BASIC_AUTH $FLOWER_BASIC_AUTH
-cf start performance-platform-stagecraft-flower
+cf push performance-platform-stagecraft-flower
 
 # create and map routes
 cf map-route performance-platform-stagecraft-web cloudapps.digital --hostname performance-platform-stagecraft-$PAAS_SPACE


### PR DESCRIPTION
The problem is caused by "split brain" environment variables. Where some
are set in the manifest and some in the deploy script some are getting
missed by a `cf start`. Presumably a `--no-start` doesn't push up the
environment variables.
