### PR TITLE
Fix regression in cf handling of yaml anchors.

### DIFF
--- a/etc/deploy.sh
+++ b/etc/deploy.sh
@@ -77,6 +77,7 @@ cf push performance-platform-stagecraft-celery-cam
 cycle_app performance-platform-stagecraft-flower
 cf set-env performance-platform-stagecraft-flower REDIS_DATABASE_NUMBER $REDIS_DATABASE_NUMBER
 cf set-env performance-platform-stagecraft-flower FLOWER_BASIC_AUTH $FLOWER_BASIC_AUTH
+cf set-env performance-platform-stagecraft-flower CELERY_CONFIG_MODULE "stagecraft.settings.rediss"
 cf push performance-platform-stagecraft-flower
 
 # create and map routes

--- a/manifest.yml
+++ b/manifest.yml
@@ -27,6 +27,11 @@ applications:
     command: python manage.py celeryd --settings=$DJANGO_SETTINGS_MODULE -E -l debug
     env:
       DISABLE_COLLECTSTATIC: 1
+      DEBUG: 0
+      ENV_HOSTNAME: performance-platform-stagecraft.cloudapps.digital
+      PUBLIC_HOSTNAME: performance-platform-stagecraft.cloudapps.digital
+      STATIC_URL: /assets/
+      STAGECRAFT_BROKER_SSL_CERT_REQS: CERT_NONE
 
   - name: performance-platform-stagecraft-celery-beat
     <<: *defaults
@@ -34,6 +39,11 @@ applications:
     memory: 128M
     env:
       DISABLE_COLLECTSTATIC: 1
+      DEBUG: 0
+      ENV_HOSTNAME: performance-platform-stagecraft.cloudapps.digital
+      PUBLIC_HOSTNAME: performance-platform-stagecraft.cloudapps.digital
+      STATIC_URL: /assets/
+      STAGECRAFT_BROKER_SSL_CERT_REQS: CERT_NONE
 
   - name: performance-platform-stagecraft-celery-cam
     <<: *defaults
@@ -41,9 +51,19 @@ applications:
     memory: 128M
     env:
       DISABLE_COLLECTSTATIC: 1
+      DEBUG: 0
+      ENV_HOSTNAME: performance-platform-stagecraft.cloudapps.digital
+      PUBLIC_HOSTNAME: performance-platform-stagecraft.cloudapps.digital
+      STATIC_URL: /assets/
+      STAGECRAFT_BROKER_SSL_CERT_REQS: CERT_NONE
 
   - name: performance-platform-stagecraft-flower
     <<: *defaults
     command: etc/run_flower.sh
     env:
       DISABLE_COLLECTSTATIC: 1
+      DEBUG: 0
+      ENV_HOSTNAME: performance-platform-stagecraft.cloudapps.digital
+      PUBLIC_HOSTNAME: performance-platform-stagecraft.cloudapps.digital
+      STATIC_URL: /assets/
+      STAGECRAFT_BROKER_SSL_CERT_REQS: CERT_NONE


### PR DESCRIPTION
Between 6.36 and 6.38 of cf-cli the behaviour of yaml anchors, specifically
relating to `env` regressed so it no longer picks up the "common" ones.