### PR TITLE
Bump cryptography package version

### DIFF
--- a/requirements/_common.txt
+++ b/requirements/_common.txt
@@ -13,7 +13,7 @@ jsonfield==2.0.1
 requests==2.13.0
 logstash_formatter==0.5.16
 jsonschema==2.6.0
-cryptography==1.9
+cryptography==2.7
 redis==2.10.5
 git+git://github.com/alphagov/flower.git@0.9.2-rediss#egg=flower
 


### PR DESCRIPTION
Richard Towers has found that you can pip install this with our buildpack and it works. This is probably because it includes the compiled binaries in a wheel instead of requiring us to build them out of tar.gz.